### PR TITLE
tz= to tzstr= to avoid partial argument match

### DIFF
--- a/R/nanotime.R
+++ b/R/nanotime.R
@@ -124,7 +124,7 @@ setMethod("nanotime",
               format <- .getFormat(format)
               tz <- .getTz(x, tz)
               n <- names(x)
-              d <- RcppCCTZ::parseDouble(x, fmt=format, tz=tz)
+              d <- RcppCCTZ::parseDouble(x, fmt=format, tzstr=tz)
               res <- new("nanotime", as.integer64(d[,1]) * as.integer64(1e9) + as.integer64(d[, 2]))
               if (!is.null(n)) {
                   names(S3Part(res, strictS3=TRUE)) <- n


### PR DESCRIPTION
Hi Dirk,
In data.table we now run tests with R's `warnPartialMatchArgs` turned on. This revealed this one line in nanotime since we have tests of nanotime with data.table.
```R
> options(warnPartialMatchArgs=TRUE)
> nanotime("2016-09-28T15:30:00.000000070Z")
[1] "2016-09-28T15:30:00.000000070+00:00"
Warning message:
In RcppCCTZ::parseDouble(x, fmt = format, tz = tz) :
  partial argument match of 'tz' to 'tzstr'
```
It came up because a user wished to turn on this option for their own code in production to be strict themselves. But then internal code of data.table was caught by it too. So now we turn it on in tests, and stopped relying on partial argument match ourselves in internal data.table code. It's a nice improvement and caught a few things. I didn't know about this option before actually.
Hope you enjoyed Toulouse.
Best, Matt