### PR TITLE
use 'nothrow' versions of 'RcppCCTZ' in order to run correctly on Win-32

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,8 @@ before_install:
 
 install:
   - ./run.sh install_aptget r-cran-bit64 r-cran-zoo r-cran-data.table r-cran-xts r-cran-tinytest
-  - ./run.sh install_r RcppDate RcppCCTZ
+  - ./run.sh install_github eddelbuettel/rcppcctz
+  - ./run.sh install_r RcppDate 
 
 script:
   - ./run.sh run_tests

--- a/R/nanoival.R
+++ b/R/nanoival.R
@@ -249,7 +249,7 @@ setMethod("as.nanoival",
                   stop("argument 'tz' must be of type 'character'")
               }
               tryCatch(nanoival_make_impl(from, tz), error=function(e) {
-                  if (e$message == "Cannot retrieve timezone") {
+                  if (grepl("Cannot retrieve timezone", e$message)) {
                       stop(e$message)
                   } else {
                       .secondaryNanoivalParse(from, format, tz)

--- a/R/nanotime.R
+++ b/R/nanotime.R
@@ -162,7 +162,7 @@ setAs("integer64", "nanotime", function(from) new("nanotime", as.integer64(from,
 
 .nanotime_character <- function(from, format="", tz="") {
     tryCatch(nanotime_make_impl(from, tz), error=function(e) {
-        if (e$message == "Cannot retrieve timezone" ||
+        if (grepl("Cannot retrieve timezone", e$message) ||
             e$message == "timezone is specified twice: in the string and as an argument") {
             stop(e$message)
         } else {

--- a/inst/include/nanotime/globals.hpp
+++ b/inst/include/nanotime/globals.hpp
@@ -49,7 +49,7 @@ namespace nanotime {
   /// 'sp' (i.e. 'se') and does not read more that expectmax
   /// characters. If the number of characters read is smaller than
   /// 'expectmin' the function raises an exception.
-  inline size_t readInt(const char*& sp, 
+  inline uint64_t readInt(const char*& sp, 
                         const char* const se,
                         const int expectmin,
                         const int expectmax) {
@@ -171,12 +171,12 @@ namespace nanotime {
       std::string tzstr_str;    // need to persist this copy!
       std::int64_t offset = 0;
       if (*sp == '+' || *sp == '-') {
-        int sign = *sp == '-' ? -1 : 1;
-        auto h_offset = readInt(++sp, se, 2, 2);
+        int64_t sign = *sp == '-' ? -1 : 1;
+        int64_t h_offset = readInt(++sp, se, 2, 2);
         if (*sp != ':' && *sp != ' ') {
           throw std::range_error("Error parsing offset");
         }
-        auto m_offset = readInt(++sp, se, 2, 2);
+	int64_t m_offset = readInt(++sp, se, 2, 2);
         offset = sign * h_offset * 3600 + m_offset * 60;
         tzstr_str = "UTC";
       } else if (isalpha(*sp)) {

--- a/src/rounding.cpp
+++ b/src/rounding.cpp
@@ -8,10 +8,14 @@ using namespace nanotime;
 
 // import function from 'RcppCCTZ':
 static inline duration getOffsetCnv(const dtime& dt, const std::string& z) {
-  typedef int GET_OFFSET_FUN(long long, const char*); 
-  GET_OFFSET_FUN *getOffset = (GET_OFFSET_FUN *) R_GetCCallable("RcppCCTZ", "_RcppCCTZ_getOffset" );
+  typedef int GET_OFFSET_FUN(long long, const char*, int&); 
+  GET_OFFSET_FUN *getOffset = (GET_OFFSET_FUN *) R_GetCCallable("RcppCCTZ", "_RcppCCTZ_getOffset_nothrow" );
 
-  auto offset = getOffset(std::chrono::duration_cast<std::chrono::seconds>(dt.time_since_epoch()).count(), z.c_str());
+  int offset;
+  int res = getOffset(std::chrono::duration_cast<std::chrono::seconds>(dt.time_since_epoch()).count(), z.c_str(), offset);
+  if (res < 0) {
+    Rcpp::stop("Cannot retrieve timezone '%s'.", z.c_str());
+  }
   return duration(offset).count() * std::chrono::seconds(1);
 }
 


### PR DESCRIPTION
Note that I did not increase rev. number - not sure if that was right or not, but was worried about creating confusion since I didn't on the last try...