### PR TITLE
Updated tests for R-devel and R-release

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,12 @@
+2020-10-24  Dirk Eddelbuettel  <edd@debian.org>
+
+	* inst/tinytest/test_nanotime.R: Add explicit check.tzone=FALSE to
+	equality test for POSIXct comparison
+        * inst/tinytest/test_nanoival.R: Renable full tests, add bit64
+        * inst/tinytest/test_nanoperiod.R: Idem
+        * inst/tinytest/test_nanotime.R: Idem
+        * inst/tinytest/test_ops.R: Idem
+
 2020-09-11  Dirk Eddelbuettel  <edd@debian.org>
 
 	* docs/: Added package website

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ most of the cases where fractional seconds are needed because it avoids floating
 
 ### Documentation
 
-Package documentation, help pages, a vignette, and more are available
+Package documentation, help pages, a vignette, and more is available
 [here](https://eddelbuettel.github.io/nanotime/).
 
 

--- a/inst/tinytest/test_nanoduration.R
+++ b/inst/tinytest/test_nanoduration.R
@@ -1,6 +1,9 @@
 
-library(nanotime)
-library(bit64)
+suppressMessages({
+    library(nanotime)
+    library(bit64)
+})
+options(digits=7)                       # needed for error message below
 
 milli <- 1e6
 sec <- 1e9
@@ -442,7 +445,6 @@ expect_identical(all.equal(as.nanoduration(1), as.nanoduration(2e9), scale=1), "
 ## test rounding functions:
 
 ## nano_ceiling:
-if (getRversion() >= as.package_version("4.1.0")) exit_file("skip remainder")
 ## hours:
 expect_identical(nano_ceiling(as.nanotime("2010-10-10 12:00:00 UTC"), as.nanoduration("06:00:00")),
                  as.nanotime("2010-10-10T12:00:00+00:00"))

--- a/inst/tinytest/test_nanoival.R
+++ b/inst/tinytest/test_nanoival.R
@@ -1,6 +1,5 @@
 library(nanotime)
 
-if (getRversion() >= as.package_version("4.1.0")) exit_file("skip for now")
 isSolaris <- Sys.info()[["sysname"]] == "SunOS"
 
 savedFormat <- NULL

--- a/inst/tinytest/test_nanoperiod.R
+++ b/inst/tinytest/test_nanoperiod.R
@@ -1,5 +1,8 @@
 
-library(nanotime)
+suppressMessages({
+    library(nanotime)
+    library(bit64)
+})
 
 isSolaris <- Sys.info()[["sysname"]] == "SunOS"
 
@@ -265,7 +268,6 @@ expect_error(as.nanoperiod(1) - "a", "invalid operand types")
 expect_error("a" - as.nanoperiod(1), "invalid operand types")
 expect_error(as.nanoperiod(1) - nanotime(1), "invalid operand types")
 
-if (getRversion() >= as.package_version("4.1.0")) exit_file("skip_remainder")
 ## +
 ##test_nanoperiod_plus_nanoperiod <- function() {
 expect_identical(+as.nanoperiod("2m"), as.nanoperiod("2m"))

--- a/inst/tinytest/test_nanotime.R
+++ b/inst/tinytest/test_nanotime.R
@@ -1,5 +1,9 @@
 
-library(nanotime)
+suppressMessages({
+    library(nanotime)
+    library(bit64)
+})
+options(digits=7)                       # needed for error message of 0.3333333 below
 
 expect_equal_numeric <- function(x,y,...) expect_equal(as.numeric(x), as.numeric(y), ...)
 
@@ -12,8 +16,6 @@ expect_identical(nanotime(1), new("nanotime", as.integer64(1)))
 expect_identical(nanotime(as.integer64(1)), new("nanotime", as.integer64(1)))
 expect_identical(as.nanotime(1), new("nanotime", as.integer64(1)))
 expect_identical(as.nanotime(as.integer64(1)), new("nanotime", as.integer64(1)))
-
-if (getRversion() >= as.package_version("4.1.0")) exit_file("skip remainder")
 
 ##test_nanotime_character_first_pass <- function() {
 ## we do a first pass parsing, which is faster than the parsing
@@ -311,12 +313,12 @@ options(nanotimeTz="America/New_York")
 b <- nanotime(0)
 p <- as.POSIXct(b)
 ## LLL: not fully satisfactory here; nanotime will not have 'tz' set from the environment:
-expect_equal(p, as.POSIXct("1969-12-31 19:00:00", tz="America/New_York"))
+expect_equal(p, as.POSIXct("1969-12-31 19:00:00", tz="America/New_York"), check.tzone=FALSE)
 
 options(nanotimeTz=NULL)
 c <- nanotime(0)
 p <- as.POSIXct(c)
-expect_equal(p, as.POSIXct("1970-01-01 00:00:00", tz="UTC"))
+expect_equal(p, as.POSIXct("1970-01-01 00:00:00", tz="UTC"), check.tzone=FALSE)
 
 options(nanotimeTz=oldTz)
 

--- a/inst/tinytest/test_ops.R
+++ b/inst/tinytest/test_ops.R
@@ -1,5 +1,8 @@
 
-library(nanotime)
+suppressMessages({
+    library(nanotime)
+    library(bit64)
+})
 
 ## ------------ `-`
 #"test_nanotime-nanotime" <- function() {
@@ -85,7 +88,6 @@ expect_true(!(as.integer64(1) < nanotime(1)))
 expect_true(!(1L < nanotime(1)))
 expect_true(!(1 < nanotime(1)))
 
-if (getRversion() >= as.package_version("4.1.0")) exit_file("skip remainder")
 #test_compare_character_nanotime <- function() {
 expect_true(isFALSE("2018-12-28T16:34:59.649943448+00:00" < nanotime("2018-12-28T16:34:59.000000000+00:00")))
 expect_true("2018-12-28T16:34:59.649943448+00:00" >  nanotime("2018-12-28T16:34:59.000000000+00:00"))


### PR DESCRIPTION
R-devel itself got some fixed since we first ran into this so the restriction could be removed from a few test files.  

We also add the (new in R 4.0.0 IIRC) `check.tzone=FALSE` argument used by `all.equal.POSIXt`.  One tests gets an explicit formatting option (to ensure the error return string is matched), and we load `bit64` in more files to be able to run the files indiviually via `tinytest::run_test_file(filename)`.