### PR TITLE
Comparaison nanoduration and character

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,40 @@
+# Run CI for R using https://eddelbuettel.github.io/r-ci/
+
+name: ci
+
+on:
+  push:
+  pull_request:
+
+env:
+  USE_BSPM: "true"
+  _R_CHECK_FORCE_SUGGESTS_: "false"
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        config:
+          - {os: macOS-latest}
+          - {os: ubuntu-latest}
+
+    runs-on: ${{ matrix.config.os }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Bootstrap
+        run: |
+          curl -OLs https://eddelbuettel.github.io/r-ci/run.sh
+          chmod 0755 run.sh
+          ./run.sh bootstrap
+
+      - name: Dependencies
+        run: ./run.sh install_all
+
+      - name: Test
+        run: ./run.sh run_tests
+
+      - name: Coverage
+        run: ./run.sh coverage
+        

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,27 @@
-# Run Travis CI for R using https://eddelbuettel.github.io/r-travis/
+# Run CI for R using https://eddelbuettel.github.io/r-ci/
 
 language: c
 sudo: required
-dist: bionic
+dist: focal
 
 jobs:
   include:
-    - name: r-4.0
-      env: R_VERSION="4.0"
+    - name: linux
+      os: linux
+    #- name: macOS
+    #  os: osx
+
+env:
+  global:
+    - USE_BSPM="true"
+    - _R_CHECK_FORCE_SUGGESTS_="false"
 
 before_install:
-  - curl -OLs https://eddelbuettel.github.io/r-travis/run.sh && chmod 0755 run.sh
-  # add our launchpad repo which has (inter alia) r-cran-rcppcctz
-  # - sudo add-apt-repository -y ppa:edd/r-3.5
+  - curl -OLs https://eddelbuettel.github.io/r-ci/run.sh && chmod 0755 run.sh
   - ./run.sh bootstrap
 
 install:
-  - ./run.sh install_aptget r-cran-bit64 r-cran-zoo r-cran-data.table r-cran-xts r-cran-tinytest
-  - ./run.sh install_r RcppDate RcppCCTZ
+  - ./run.sh install_all
 
 script:
   - ./run.sh run_tests
@@ -27,7 +31,7 @@ after_failure:
 
 after_success:
   - ./run.sh coverage
-   
+
 notifications:
   email:
     on_success: change

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,7 @@
 2020-12-06  Dirk Eddelbuettel  <edd@debian.org>
 
+	* DESCRIPTION (Version, Date): Roll minor version
+
 	* .travis.yml: Switch to run.sh from r-ci for focal and bspm
 	* .github/workflows/ci.yaml: Use run.sh from r-ci
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,17 @@
+2020-12-06  Dirk Eddelbuettel  <edd@debian.org>
+
+	* .travis.yml: Switch to run.sh from r-ci for focal and bspm
+
+2020-12-06  Colin Umansky  <statquant@outlook.com>
+
+	* inst/tinytest/test_nanoduration.R: Added tests for comparison
+
+2020-12-05  Colin Umansky  <statquant@outlook.com>
+
+	* R/nanoduration.R: Support nanoduration to character comparison
+	* man/nanoduration.Rd: Document new feature
+	* inst/tinytest/test_nanoduration.R: Updated tests
+
 2020-10-25  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Roll minor version

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 2020-12-06  Dirk Eddelbuettel  <edd@debian.org>
 
 	* .travis.yml: Switch to run.sh from r-ci for focal and bspm
+	* .github/workflows/ci.yaml: Use run.sh from r-ci
 
 2020-12-06  Colin Umansky  <statquant@outlook.com>
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,7 @@ Imports: methods, bit64, RcppCCTZ (>= 0.2.9), zoo
 Suggests: tinytest, data.table, xts
 LinkingTo: Rcpp, RcppCCTZ, RcppDate
 License: GPL (>= 2)
-RoxygenNote: 7.1.1.9000
+RoxygenNote: 7.1.1
 Collate:
   'nanotime.R'
   'nanoival.R'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: nanotime
 Type: Package
 Title: Nanosecond-Resolution Time Support for R
-Version: 0.3.2.2
-Date: 2020-10-25
+Version: 0.3.2.3
+Date: 2020-12-06
 Author: Dirk Eddelbuettel and Leonardo Silvestri
 Maintainer: Dirk Eddelbuettel <edd@debian.org>
 Description: Full 64-bit resolution date and time functionality with

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,7 @@ Imports: methods, bit64, RcppCCTZ (>= 0.2.9), zoo
 Suggests: tinytest, data.table, xts
 LinkingTo: Rcpp, RcppCCTZ, RcppDate
 License: GPL (>= 2)
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.1.9000
 Collate:
   'nanotime.R'
   'nanoival.R'

--- a/R/nanoduration.R
+++ b/R/nanoduration.R
@@ -54,6 +54,11 @@ setClass("nanoduration", contains = "integer64")
 ##' as.nanoduration("24:00:00") / 2
 ##' as.nanoduration("24:00:00") / as.nanoduration("12:00:00")
 ##'
+##' ## comparison:
+##' as.nanoduration("10:03:02.999_999_999") == 36182999999999
+##' as.nanoduration("10:03:02.999_999_999") > as.nanoduration("10:03:02.999_999_998")
+##' as.nanoduration("10:03:02.999_999_998") < "10:03:02.999_999_999"
+##'
 ##' @seealso
 ##' \code{\link{nanotime}}
 ##'
@@ -385,6 +390,20 @@ setMethod("/", c("ANY", "nanoduration"),
 setMethod("Arith", c("nanoduration", "ANY"),
           function(e1, e2) {
               callNextMethod(S3Part(e1, strictS3=TRUE), e2)
+          })
+
+##' @rdname nanoduration
+setMethod("Compare", c("nanoduration", "character"),
+          function(e1, e2) {
+              ne2 <- as.nanoduration(e2)
+              callNextMethod(e1, ne2)
+          })
+
+##' @rdname nanoduration
+setMethod("Compare", c("character", "nanoduration"),
+          function(e1, e2) {
+              ne1 <- as.nanoduration(e1)
+              callNextMethod(ne1, e2)
           })
 
 ##' @rdname nanoduration

--- a/inst/tinytest/test_nanoduration.R
+++ b/inst/tinytest/test_nanoduration.R
@@ -387,6 +387,33 @@ expect_error(as.nanoduration(1) < "a", "cannot parse nanoduration")
 ##test_Compare_ANY_nanoduration <- function() {
 expect_error("a" < as.nanoduration(1), "cannot parse nanoduration")
 
+##test_Compare_character_nanoduration <- function() {
+expect_true("12:13:14.151617" == as.nanoduration("12:13:14.151617"))
+expect_false("12:13:14.151617" == as.nanoduration("12:13:14.151617001"))
+expect_true("12:13:14.151617" != as.nanoduration("12:13:14.151617001"))
+expect_false("12:13:14.151617" != as.nanoduration("12:13:14.151617"))
+expect_true("12:13:14.151617" < as.nanoduration("12:13:14.151617001"))
+expect_false("12:13:14.151617001" < as.nanoduration("12:13:14.151617"))
+expect_true("12:13:14.151617" <= as.nanoduration("12:13:14.151617"))
+expect_false("12:13:14.151617001" <= as.nanoduration("12:13:14.151617"))
+expect_true("12:13:14.151617001" > as.nanoduration("12:13:14.151617"))
+expect_false("12:13:14.151617" > as.nanoduration("12:13:14.151617001"))
+expect_true("12:13:14.151617" >= as.nanoduration("12:13:14.151617"))
+expect_false("12:13:14.151617" >= as.nanoduration("12:13:14.151617001"))
+ 
+##test_Compare_nanoduration_character <- function() {
+expect_true(as.nanoduration("12:13:14.151617") == "12:13:14.151617")
+expect_false(as.nanoduration("12:13:14.151617") == "12:13:14.151617001")
+expect_true(as.nanoduration("12:13:14.151617") != "12:13:14.151617001")
+expect_false(as.nanoduration("12:13:14.151617") != "12:13:14.151617")
+expect_true(as.nanoduration("12:13:14.151617") < "12:13:14.151617001")
+expect_false(as.nanoduration("12:13:14.151617001") < "12:13:14.151617")
+expect_true(as.nanoduration("12:13:14.151617") <= "12:13:14.151617")
+expect_false(as.nanoduration("12:13:14.151617001") <= "12:13:14.151617")
+expect_true(as.nanoduration("12:13:14.151617001") > "12:13:14.151617")
+expect_false(as.nanoduration("12:13:14.151617") > "12:13:14.151617001")
+expect_true(as.nanoduration("12:13:14.151617") >= "12:13:14.151617")
+expect_false(as.nanoduration("12:13:14.151617") >= "12:13:14.151617001")
 
 ## Arith
 ##test_Arith <- function() {

--- a/inst/tinytest/test_nanoduration.R
+++ b/inst/tinytest/test_nanoduration.R
@@ -375,8 +375,8 @@ expect_error(round(as.nanoduration(1)), "non-numeric argument to mathematical fu
 
 ## Compare
 ##test_Compare_nanoduration_ANY <- function() {
-expect_true(is.na(as.nanoduration(1) < "a")) # this is what "integer64" gives back, but do we want to change that to an error? LLL
-## not quite clear in R either:
+expect_error(as.nanoduration(1) < "a", "cannot parse nanoduration")
+## not quite clear in R:
 ## > 1 < list(1)
 ## [1] FALSE
 ## > 1 > list(1)
@@ -385,7 +385,7 @@ expect_true(is.na(as.nanoduration(1) < "a")) # this is what "integer64" gives ba
 ## [1] TRUE  
 
 ##test_Compare_ANY_nanoduration <- function() {
-expect_true(is.na("a" < as.nanoduration(1))) # this is what "integer64" gives back, but do we want to change that to an error? LLL
+expect_error("a" < as.nanoduration(1), "cannot parse nanoduration")
 
 
 ## Arith

--- a/man/nanoduration.Rd
+++ b/man/nanoduration.Rd
@@ -56,6 +56,8 @@
 \alias{/,nanoduration,integer64-method}
 \alias{/,nanoduration,numeric-method}
 \alias{Arith,nanoduration,ANY-method}
+\alias{Compare,nanoduration,character-method}
+\alias{Compare,character,nanoduration-method}
 \alias{Compare,nanoduration,ANY-method}
 \alias{abs,nanoduration-method}
 \alias{sign,nanoduration-method}
@@ -153,6 +155,10 @@ nanoduration(hours, minutes, seconds, nanoseconds)
 \S4method{/}{nanoduration,numeric}(e1, e2)
 
 \S4method{Arith}{nanoduration,ANY}(e1, e2)
+
+\S4method{Compare}{nanoduration,character}(e1, e2)
+
+\S4method{Compare}{character,nanoduration}(e1, e2)
 
 \S4method{Compare}{nanoduration,ANY}(e1, e2)
 
@@ -252,6 +258,11 @@ as.nanoduration(10e9) - as.nanoduration(9e9)
 as.nanoduration(10e9) + as.nanoduration(-9e9)
 as.nanoduration("24:00:00") / 2
 as.nanoduration("24:00:00") / as.nanoduration("12:00:00")
+
+## comparison:
+as.nanoduration("10:03:02.999_999_999") == 36182999999999
+as.nanoduration("10:03:02.999_999_999") > as.nanoduration("10:03:02.999_999_998")
+as.nanoduration("10:03:02.999_999_998") < "10:03:02.999_999_999"
 
 }
 \seealso{


### PR DESCRIPTION
Following [#87](https://github.com/eddelbuettel/nanotime/issues/87) here is a PR that allows comparaison between nanoduration and character. Functionality-wise I think it makes sense as it mimics nanotime behavior and base R Date behavior.
It builds locally and passes all tinytests.
I had to modify 2 tests that would have failed.
If you're ok with adding the functionality please let me know if I should check/change/fix anything.
Regards