### PR TITLE
fix for 'plus' and 'minus' functions when crossing timezone DST boundary

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2021-08-09 Leonardo Silvestri <lsilvestri@ztsdb.org>
+	* src/period.cpp:  Fix for `plus` and `minus` adjustment
+	* R/nanoperiod.R: Idem
+        * inst/tinytest/test_nanoperiod.R: Idem
+	* man/nanoperiod.Rd: Idem
+
 2021-04-06  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (URL, BugRreports): Added to DESCRIPTION file

--- a/R/nanoperiod.R
+++ b/R/nanoperiod.R
@@ -26,10 +26,19 @@ setClass("nanoperiod", contains = "complex")
 ##'
 ##'
 ##'
-##' Adding or subtracting \code{nanoperiod} and \code{nanotime} require a
-##' timezone as third argument. For this reason it is not possible to
-##' use the binary operator `code{+}`. Instead the functions
-##' `\code{plus}` and `\code{minus}` are defined.
+##' Adding or subtracting \code{nanoperiod} and \code{nanotime}
+##' require a timezone as third argument. For this reason it is not
+##' possible to use the binary operator `code{+}`. Instead the
+##' functions `\code{plus}` and `\code{minus}` are defined. These
+##' functions attempt to keep the same offset within a day in the
+##' specified timezone: this means for instance that adding a day when
+##' that day crosses a time zone adjustment such as a daylight saving
+##' time, results in a true time increment of less or more than 24
+##' hours to preserve the offset. Preserving the offset works for
+##' increments that are smaller than a day too, provided the increment
+##' results in a datetime where the timezone adjustment is valid. When
+##' this is not the case, adding a `nanoperiod` behaves in the same
+##' way as adding a `nanoduration`.
 ##'
 ##'
 ##' @param x,value An object of class \code{nanoperiod}

--- a/inst/tinytest/test_nanoperiod.R
+++ b/inst/tinytest/test_nanoperiod.R
@@ -522,7 +522,94 @@ if (!isSolaris) {
     tz <- "America/New_York"
     expect_error(minus(p, nt, tz), "operation not defined for 'nanoperiod' objects")
 
+    ## test the crossing of daylight saving time in both directions:
 
+    ## adding/subtracting a nanoperiod should not realign if doing so
+    ## crosses again a DST boundary:
+
+    ## look at cases over the Spring boundary in America:
+    nt <- as.nanotime("2020-03-08 01:45:30 America/New_York")
+    p <- as.nanoperiod("00:30:00")
+    tz <- "America/New_York"
+    expected <- as.nanotime("2020-03-08 03:15:30 America/New_York")
+    expect_identical(plus(nt, p, tz), expected)
+
+    nt <- as.nanotime("2020-03-08 01:00:00 America/New_York")
+    p <- as.nanoperiod("01:00:00")
+    tz <- "America/New_York"
+    expected <- as.nanotime("2020-03-08 03:00:00 America/New_York")
+    expect_identical(plus(nt, p, tz), expected)
+
+    nt <- as.nanotime("2020-03-08 03:15:30 America/New_York")
+    p <- as.nanoperiod("00:30:00")
+    tz <- "America/New_York"
+    expected <- as.nanotime("2020-03-08 01:45:30 America/New_York")
+    expect_identical(minus(nt, p, tz), expected)
+
+    nt <- as.nanotime("2020-03-08 03:00:00 America/New_York")
+    p <- as.nanoperiod("01:00:00")
+    tz <- "America/New_York"
+    expected <- as.nanotime("2020-03-08 01:00:00 America/New_York")
+    expect_identical(minus(nt, p, tz), expected)
+
+    ## look at the cases over the Autumn boundary in America:
+    nt <- as.nanotime("2020-11-01 01:45:30 America/New_York")
+    p <- as.nanoperiod("00:30:00")
+    tz <- "America/New_York"
+    expected <- as.nanotime("2020-11-01 02:15:30 America/New_York")
+    expect_identical(plus(nt, p, tz), expected)
+
+    nt <- as.nanotime("2020-11-01 01:00:00 America/New_York")
+    p <- as.nanoperiod("01:00:00")
+    tz <- "America/New_York"
+    expected <- as.nanotime("2020-11-01 02:00:00 America/New_York")
+    expect_identical(plus(nt, p, tz), expected)
+
+    nt <- as.nanotime("2020-11-01 02:15:30 America/New_York")
+    p <- as.nanoperiod("00:30:00")
+    tz <- "America/New_York"
+    ##expected <- as.nanotime("2020-11-01 01:45:30 America/New_York")  # ambiguous
+    expected <- as.nanotime("2020-11-01 06:45:30+00:00")
+    expect_identical(minus(nt, p, tz), expected)
+
+    nt <- as.nanotime("2020-11-01 02:00:00 America/New_York")
+    p <- as.nanoperiod("01:00:00")
+    tz <- "America/New_York"
+    ## expected <- as.nanotime("2020-11-01 01:00:00 America/New_York")    # ambiguous
+    expected <- as.nanotime("2020-11-01 06:00:00+00:00")
+    expect_identical(minus(nt, p, tz), expected)
+    
+    
+    ## adding/subtracting a nanoperiod should realign if doing so does
+    ## not cross again a DST boundary:    
+
+    ## look at cases over the Spring boundary in America:
+    nt <- as.nanotime("2020-03-08 01:00:00 America/New_York")
+    p <- as.nanoperiod("02:00:01")
+    tz <- "America/New_York"
+    expected <- as.nanotime("2020-03-08 03:00:01 America/New_York")
+    expect_identical(plus(nt, p, tz), expected)
+
+    nt <- as.nanotime("2020-03-08 03:00:00 America/New_York")
+    p <- as.nanoperiod("02:00:01")
+    tz <- "America/New_York"
+    expected <- as.nanotime("2020-03-08 00:59:59 America/New_York")
+    expect_identical(minus(nt, p, tz), expected)
+
+    ## look at the cases over the Autumn boundary in America:
+    nt <- as.nanotime("2020-11-01 01:00:00 America/New_York")
+    p <- as.nanoperiod("02:00:01")
+    tz <- "America/New_York"
+    expected <- as.nanotime("2020-11-01 03:00:01 America/New_York")
+    expect_identical(plus(nt, p, tz), expected)
+
+    nt <- as.nanotime("2020-11-01 03:00:00 America/New_York")
+    p <- as.nanoperiod("02:00:01")
+    tz <- "America/New_York"
+    expected <- as.nanotime("2020-11-01 00:59:59 America/New_York")
+    expect_identical(minus(nt, p, tz), expected)
+    
+    
     ## plus/minus with 'nanoival':
 
     ##test_plus_nanoival_nanoperiod <- function() {

--- a/man/nanoperiod.Rd
+++ b/man/nanoperiod.Rd
@@ -263,10 +263,19 @@ like this: \code{10m2d/10:12:34.123_453_000}.
 
 
 
-Adding or subtracting \code{nanoperiod} and \code{nanotime} require a
-timezone as third argument. For this reason it is not possible to
-use the binary operator `code{+}`. Instead the functions
-`\code{plus}` and `\code{minus}` are defined.
+Adding or subtracting \code{nanoperiod} and \code{nanotime}
+require a timezone as third argument. For this reason it is not
+possible to use the binary operator `code{+}`. Instead the
+functions `\code{plus}` and `\code{minus}` are defined. These
+functions attempt to keep the same offset within a day in the
+specified timezone: this means for instance that adding a day when
+that day crosses a time zone adjustment such as a daylight saving
+time, results in a true time increment of less or more than 24
+hours to preserve the offset. Preserving the offset works for
+increments that are smaller than a day too, provided the increment
+results in a datetime where the timezone adjustment is valid. When
+this is not the case, adding a `nanoperiod` behaves in the same
+way as adding a `nanoduration`.
 }
 
 \examples{

--- a/src/period.cpp
+++ b/src/period.cpp
@@ -158,9 +158,15 @@ dtime nanotime::plus(const dtime& dt, const period& p, const std::string& z) {
   offset = getOffsetCnv(dt, z);
   res += p.getDays()*std::chrono::hours(24);
   res += p.getDuration();
-  auto newoffset = getOffsetCnv(res, z);
-  if (newoffset != offset) {
-    res += offset - newoffset; // adjust for DST or any other event that changed the TZ
+  auto new_offset = getOffsetCnv(res, z);
+  // adjust for DST or any other event that changed the TZ, but only
+  // if the adjustment does not put us back in the old offset:
+  if (new_offset != offset) {
+    auto res_potential = res + offset - new_offset; // adjust
+    auto adjusted_offset = getOffsetCnv(res_potential, z);
+    if (adjusted_offset == new_offset) { // are we still in the new offset?
+      res = res_potential;               // if so, then keep the adjustment
+    }
   }
   return res;
 }


### PR DESCRIPTION
The true problem was in `plus` and `minus`, which were affecting `floor`. Didn't udpate DESCRIPTION - wasn't sure about the versioning...