### PR TITLE
fix %in% and negative 'nanoperiod' parse. closes #96 #99

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2021-03-06  Leonardo Silvestri  <lsilvestri@ztsdb.org>
+
+	* DESCRIPTION (Version, Date): Release 0.3.6
+	* R/nanoival.R: Fix incorrect subsetting with operator `%in%`
+	* NAMESPACE: Added export
+	* man/set_operations.Rd: Added file
+	* src/period.cpp: Fix parse of negative period
+
 2021-12-14  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Release 0.3.5

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: nanotime
 Type: Package
 Title: Nanosecond-Resolution Time Support for R
-Version: 0.3.5
-Date: 2021-12-14
+Version: 0.3.6
+Date: 2022-03-06
 Author: Dirk Eddelbuettel and Leonardo Silvestri
 Maintainer: Dirk Eddelbuettel <edd@debian.org>
 Description: Full 64-bit resolution date and time functionality with

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -112,5 +112,5 @@ exportMethods(nano_year)
 exportMethods(nano_ceiling)
 exportMethods(nano_floor)
 
-export("%in%.nanotime")
 S3method("%in%", nanotime)
+exportMethods("%in%")

--- a/R/nanoival.R
+++ b/R/nanoival.R
@@ -739,7 +739,7 @@ setMethod("intersect.idx",
 
 
 ##' @rdname set_operations
-##' @aliases %in%.nanotime
+##' @method %in% nanotime
 `%in%.nanotime` <- function(x, table) {
     if (class(table) == "nanoival") {
         if (is.unsorted(x)) stop("x must be sorted")
@@ -750,15 +750,14 @@ setMethod("intersect.idx",
     }
 }
 
-## ##' @rdname set_operations
-## ##' @aliases %in%,nanotime,nanoival-method
-## setMethod("%in%",
-##           c("nanotime", "nanoival"),
-##           function(x, table) {
-##               if (is.unsorted(x)) stop("x must be sorted")
-##               table <- sort(table)
-##               nanoival_intersect_idx_time_interval_logical_impl(x, table)
-##           })
+##' @rdname set_operations
+setMethod("%in%",
+          c("nanotime", "nanoival"),
+          function(x, table) {
+              if (is.unsorted(x)) stop("x must be sorted")
+              table <- sort(table)
+              nanoival_intersect_idx_time_interval_logical_impl(x, table)
+          })
 
 ##' @rdname set_operations
 setMethod("intersect",

--- a/R/nanoival.R
+++ b/R/nanoival.R
@@ -754,9 +754,9 @@ setMethod("intersect.idx",
 setMethod("%in%",
           c("nanotime", "nanoival"),
           function(x, table) {
-              if (is.unsorted(x)) stop("x must be sorted")
-              table <- sort(table)
-              nanoival_intersect_idx_time_interval_logical_impl(x, table)
+              if (is.unsorted(x)) stop("x must be sorted")   ## #nocov
+              table <- sort(table)                           ## #nocov
+              nanoival_intersect_idx_time_interval_logical_impl(x, table)  ## #nocov
           })
 
 ##' @rdname set_operations

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -3,6 +3,15 @@
 \newcommand{\ghpr}{\href{https://github.com/eddelbuettel/nanotime/pull/#1}{##1}}
 \newcommand{\ghit}{\href{https://github.com/eddelbuettel/nanotime/issues/#1}{##1}}
 
+\section{Changes in version 0.3.6 (2022-03-06)}{
+  \itemize{
+    \item Fix incorrect subsetting with operator \code{\%in\%} (Leonardo
+    in \ghpr{100} fixing \ghit{99}
+    \item Fix incorrect parsing for negative nanoperiod (Leonardo in
+    \ghpr{x} fixing \ghit{96}
+  }
+}
+
 \section{Changes in version 0.3.5 (2021-12-14)}{
   \itemize{
     \item Applied patch by Tomas Kalibera for Windows UCRT under the

--- a/inst/tinytest/test_nanoperiod.R
+++ b/inst/tinytest/test_nanoperiod.R
@@ -38,6 +38,10 @@ expect_identical(as.character(as.nanoperiod("1y/00:01:01")), "12m0d/00:01:01")
 expect_identical(as.character(as.nanoperiod("1w/00:01:01")), "0m7d/00:01:01")
 expect_identical(names(as.nanoperiod(c(a="1m"))), "a")
 
+## check negative duration
+expect_identical(as.nanoperiod("-00:00:01"), as.nanoperiod(as.nanoduration("-00:00:01")))
+expect_identical(as.nanoperiod("-0:00:01"), as.nanoperiod(as.nanoduration("-00:00:01")))
+
 ##test_as.nanoperiod_character_error <- function() {
 expect_error(as.nanoperiod("1wm00:01:01"), "cannot parse nanoperiod")
 expect_error(as.nanoperiod("1ym00:01:01"), "cannot parse nanoperiod")

--- a/man/set_operations.Rd
+++ b/man/set_operations.Rd
@@ -7,6 +7,7 @@
 \alias{intersect.idx,nanotime,nanoival-method}
 \alias{intersect.idx}
 \alias{\%in\%.nanotime}
+\alias{\%in\%,nanotime,nanoival-method}
 \alias{intersect,nanotime,nanoival-method}
 \alias{setdiff,nanotime,nanoival-method}
 \alias{setdiff.idx,nanotime,nanoival-method}
@@ -25,6 +26,8 @@
 \S4method{intersect.idx}{nanotime,nanoival}(x, y)
 
 \method{\%in\%}{nanotime}(x, table)
+
+\S4method{\%in\%}{nanotime,nanoival}(x, table)
 
 \S4method{intersect}{nanotime,nanoival}(x, y)
 

--- a/src/period.cpp
+++ b/src/period.cpp
@@ -42,7 +42,13 @@ period::period(const std::string& str) {
   dur    = std::chrono::seconds(0);
 
   int n;
-  if (s < e && (*s == '/' || (s+2 < e && s[2] == ':'))) goto getduration;
+  if (s < e && (*s == '/' || (*s != '-' && s+2 < e && s[2] == ':'))) goto getduration;
+  // test the case where we have only a negative duration:
+  if (s < e && *s == '-' &&
+      ((s+3 < e && s[3] == ':') || (s+2 < e && s[2] == ':'))) {      
+    --s;  // because getduration will increment it
+    goto getduration;
+  }
   if (!readNumber(s, e, n, true) || s == e) throw std::range_error("cannot parse nanoperiod");
   if (*s == 'y') {
     months += 12*n;


### PR DESCRIPTION
Changing the type on which `nanotime` is based from `integer64` to `numeric` does not solve the dispatch problems. It looks like there is a more fundamental dispatch issue in R when S3 methods are defined outside of `base`.

Here I have solved the issue by providing both S3 and S4 methods for `%in%`. When `bit64` is not explicitly loaded and no S3 method exists, the S4 method is invoked. After `bit64` is loaded the S3 method is invoked because if it is not present the `bit64` S3 method will trump the `nanotime` S4 method.

Also fixed the parsing of a `nanoperiod` when it consists of only its negative `nanoduration` part.