### PR TITLE
refactor: Use 'inherits(name)' instead of 'class() == name'

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2022-10-13  Trevor L Davis  <trevor.l.davis@gmail.com>
+
+	* R/nanotime.R: Use 'inherits()' instead of 'class() =='
+
 2022-03-06  Leonardo Silvestri  <lsilvestri@ztsdb.org>
 
 	* DESCRIPTION (Version, Date): Release 0.3.6

--- a/R/nanotime.R
+++ b/R/nanotime.R
@@ -697,7 +697,7 @@ seq.nanotime <-
     }
     if (length(from) != 1L) stop("'from' must be of length 1")
     if (!missing(to) && !is.null(to) && length(to) != 1L) stop("'to' must be of length 1")
-    if (!missing(to) && !is.null(to) && !(class(to) == "nanotime"))
+    if (!missing(to) && !is.null(to) && !(inherits(to, "nanotime")))
 	stop("'to' must be a 'nanotime'")
     if (is.null(length.out)) {
 	if (missing(by) || is.null(by))


### PR DESCRIPTION
Eliminates the following `R CMD check` NOTE:

```
❯ checking R code for possible problems ... NOTE
  Found if() conditions comparing class() to string:
  File ‘nanotime/R/nanotime.R’: if (!missing(to) && !is.null(to) && !(class(to) == "nanotime")) ...
  Use inherits() (or maybe is()) instead.
```