### PR TITLE
feat: Support default zeros in 'nanoduration()'

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,6 @@
 2022-10-13  Trevor L Davis  <trevor.l.davis@gmail.com>
 
+	* R/nanoduration.R (nanoduration): Add default arguments equal to zero
 	* R/nanotime.R: Use 'inherits()' instead of 'class() =='
 
 2022-03-06  Leonardo Silvestri  <lsilvestri@ztsdb.org>

--- a/R/nanoduration.R
+++ b/R/nanoduration.R
@@ -77,7 +77,7 @@ setClass("nanoduration", contains = "integer64")
 ##' @aliases  Summary,nanoduration-method
 ##'
 ##' @rdname nanoduration
-nanoduration <- function(hours, minutes, seconds, nanoseconds) {
+nanoduration <- function(hours = 0L, minutes = 0L, seconds = 0L, nanoseconds = 0L) {
     if (nargs()==0) {
         as.nanoduration(NULL)
     } else {

--- a/man/nanoduration.Rd
+++ b/man/nanoduration.Rd
@@ -78,7 +78,7 @@
 An object of class \code{nanoduration} of length 1.
 }
 \usage{
-nanoduration(hours, minutes, seconds, nanoseconds)
+nanoduration(hours = 0L, minutes = 0L, seconds = 0L, nanoseconds = 0L)
 
 \S4method{as.nanoduration}{character}(x)
 


### PR DESCRIPTION
* Adds default zeros to `nanoduration()` in a reverse-compatible way
* Can now do `nanoduration(seconds = 20)` instead of having to do `nanoduration(hours = 0, minutes = 0, seconds = 20, nanoseconds = 0)`