### PR TITLE
feat: Add 'as.nanoduration.difftime()'

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2022-10-14  Trevor L Davis  <trevor.l.davis@gmail.com>
+
+	* R/nanoduration.R (as.nanoduration.difftime): Added
+	* man/nanoduration.Rd: Updated
+	* inst/tinytest/test_nanoduration.R: Add tests
+
 2022-10-13  Trevor L Davis  <trevor.l.davis@gmail.com>
 
 	* R/nanoduration.R (nanoduration): Add default arguments equal to zero

--- a/R/nanoduration.R
+++ b/R/nanoduration.R
@@ -143,6 +143,19 @@ setAs("integer", "nanoduration", function(from) as.nanoduration(from))
 
 ##' @rdname nanoduration
 setMethod("as.nanoduration",
+          "difftime",
+          function(x) {
+              x <- as.numeric(x, units = "secs")
+              s <- as.integer(x) # seconds
+              n <- as.integer(1e9 * (x - s)) # nanoseconds
+              nanoduration(seconds = s, nanoseconds = n)
+})
+
+setAs("difftime", "nanoduration", function(from) as.nanoduration(from))
+
+
+##' @rdname nanoduration
+setMethod("as.nanoduration",
           "NULL",
           function(x) {
               new("nanoduration", as.integer64(NULL))

--- a/inst/tinytest/test_nanoduration.R
+++ b/inst/tinytest/test_nanoduration.R
@@ -613,3 +613,11 @@ expect_identical(nano_floor(as.nanotime("2010-10-10 12:23:23.123456789 UTC"), as
 ## rep
 expect_identical(rep(as.nanoduration(1), 2), as.nanoduration(rep(1,2)))
 expect_identical(rep(as.nanoduration(1:2), each=2), as.nanoduration(rep(1:2, each=2)))
+
+## difftime
+expect_identical(as.nanoduration(as.difftime(2, units = "secs")),
+                 nanoduration(seconds = 2))
+expect_identical(as.nanoduration(as.difftime(2.5, units = "secs")),
+                 nanoduration(seconds = 2, nanoseconds = 5e8))
+expect_identical(as.nanoduration(as.difftime(2, units = "hours")),
+                 nanoduration(hours = 2))

--- a/man/nanoduration.Rd
+++ b/man/nanoduration.Rd
@@ -22,6 +22,7 @@
 \alias{as.nanoduration,integer64-method}
 \alias{as.nanoduration,numeric-method}
 \alias{as.nanoduration,integer-method}
+\alias{as.nanoduration,difftime-method}
 \alias{as.nanoduration,NULL-method}
 \alias{as.nanoduration,missing-method}
 \alias{show,nanoduration-method}
@@ -87,6 +88,8 @@ nanoduration(hours = 0L, minutes = 0L, seconds = 0L, nanoseconds = 0L)
 \S4method{as.nanoduration}{numeric}(x)
 
 \S4method{as.nanoduration}{integer}(x)
+
+\S4method{as.nanoduration}{difftime}(x)
 
 \S4method{as.nanoduration}{`NULL`}(x)
 


### PR DESCRIPTION
For external dependency reasons I assumed you are not interested in the similar method for  `lubridate::duration()` objects:

```r
setMethod("as.nanoduration", "Duration", function(x) {
    x <- as.numeric(x, "seconds")
    s <- as.integer(x) # seconds
    n <- as.integer(1e9 * (x - s)) # nanoseconds
    nanoduration(seconds = s, nanoseconds = n)
})
```