### PR TITLE
feat: '+' / '-' methods for {nanotime} objects and 'difftime()' objects

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,7 @@
 2022-10-15  Trevor L Davis  <trevor.l.davis@gmail.com>
 
-	* R/nanoduration.R: Add '+' / '-' methods for 'diffitme()'
-	and 'nanoduration()' objects
+	* R/nanoduration.R: Add '+' / '-' methods for 'difftime()'
+	and 'nanoduration()' / 'nanotime()' objects
 	* man/nanoduration.Rd: Updated
 	* inst/tinytest/test_nanoduration.R: Add tests
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2022-10-15  Trevor L Davis  <trevor.l.davis@gmail.com>
+
+	* R/nanoduration.R: Add '+' / '-' methods for 'diffitme()'
+	and 'nanoduration()' objects
+	* man/nanoduration.Rd: Updated
+	* inst/tinytest/test_nanoduration.R: Add tests
+
 2022-10-14  Trevor L Davis  <trevor.l.davis@gmail.com>
 
 	* R/nanoduration.R (as.nanoduration.difftime): Added

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,7 @@
 2022-10-16  Trevor L Davis  <trevor.l.davis@gmail.com>
 
 	* R/nanoduration.R: Add '+' / '-' methods for 'difftime()'
-	and 'nanoduration()' / 'nanotime()' objects
+	and 'nanoduration()' / 'nanoival()' / 'nanotime()' objects
 	* man/nanoduration.Rd: Updated
 	* inst/tinytest/test_nanoduration.R: Add tests
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,4 @@
-2022-10-15  Trevor L Davis  <trevor.l.davis@gmail.com>
+2022-10-16  Trevor L Davis  <trevor.l.davis@gmail.com>
 
 	* R/nanoduration.R: Add '+' / '-' methods for 'difftime()'
 	and 'nanoduration()' / 'nanotime()' objects

--- a/R/nanoduration.R
+++ b/R/nanoduration.R
@@ -237,6 +237,11 @@ setMethod("-", c("nanoduration", "numeric"),
               new("nanoduration", S3Part(e1, strictS3=TRUE) - e2)
           })
 ##' @rdname nanoduration
+setMethod("-", c("nanoduration", "difftime"),
+          function(e1, e2) {
+              e1 - as.nanoduration(e2)
+          })
+##' @rdname nanoduration
 setMethod("-", c("nanoduration", "ANY"),
           function(e1, e2) {
               if (missing(e2)) {
@@ -268,6 +273,11 @@ setMethod("-", c("integer", "nanoduration"),
 setMethod("-", c("numeric", "nanoduration"),
           function(e1, e2) {
               new("nanoduration", e1 - S3Part(e2, strictS3=TRUE))
+          })
+##' @rdname nanoduration
+setMethod("-", c("difftime", "nanoduration"),
+          function(e1, e2) {
+              as.nanoduration(e1) - e2
           })
 ##' @rdname nanoduration
 setMethod("-", c("ANY", "nanoduration"),
@@ -302,6 +312,11 @@ setMethod("+", c("nanoduration", "numeric"),
           function(e1, e2) {
               new("nanoduration", S3Part(e1, strictS3=TRUE) + e2)
           })
+##' @rdname nanoduration
+setMethod("+", c("nanoduration", "difftime"),
+          function(e1, e2) {
+              e1 + as.nanoduration(e2)
+          })
 
 ##' @rdname nanoduration
 setMethod("+", c("nanotime", "nanoduration"),
@@ -329,6 +344,11 @@ setMethod("+", c("integer64", "nanoduration"),
 setMethod("+", c("numeric", "nanoduration"),
           function(e1, e2) {
               new("nanoduration", e1 + S3Part(e2, strictS3=TRUE))
+          })
+##' @rdname nanoduration
+setMethod("+", c("difftime", "nanoduration"),
+          function(e1, e2) {
+              as.nanoduration(e1) + e2
           })
 
 ## ----------- `*`

--- a/R/nanoduration.R
+++ b/R/nanoduration.R
@@ -260,6 +260,11 @@ setMethod("-", c("nanotime", "nanoduration"),
               new("nanotime", S3Part(e1, strictS3=TRUE) - e2)
           })
 ##' @rdname nanoduration
+setMethod("-", c("nanotime", "difftime"),
+          function(e1, e2) {
+              e1 - as.nanoduration(e2)
+          })
+##' @rdname nanoduration
 setMethod("-", c("integer64", "nanoduration"),
           function(e1, e2) {
               new("nanoduration", e1 - S3Part(e2, strictS3=TRUE))
@@ -317,11 +322,25 @@ setMethod("+", c("nanoduration", "difftime"),
           function(e1, e2) {
               e1 + as.nanoduration(e2)
           })
-
 ##' @rdname nanoduration
 setMethod("+", c("nanotime", "nanoduration"),
           function(e1, e2) {
               new("nanotime", S3Part(e1, strictS3=TRUE) + S3Part(e2, strictS3=TRUE))
+          })
+##' @rdname nanoduration
+setMethod("+", c("nanotime", "difftime"),
+          function(e1, e2) {
+              e1 + as.nanoduration(e2)
+          })
+##' @rdname nanoduration
+setMethod("+", c("nanoduration", "nanotime"),
+          function(e1, e2) {
+              new("nanotime", S3Part(e1, strictS3=TRUE) + S3Part(e2, strictS3=TRUE))
+          })
+##' @rdname nanoduration
+setMethod("+", c("difftime", "nanotime"),
+          function(e1, e2) {
+              as.nanoduration(e1) + e2
           })
 
 ##' @rdname nanoduration

--- a/R/nanoduration.R
+++ b/R/nanoduration.R
@@ -88,6 +88,7 @@ nanoduration <- function(hours = 0L, minutes = 0L, seconds = 0L, nanoseconds = 0
     }
 }
 
+setOldClass("difftime")
 
 ##' @noRd
 setGeneric("as.nanoduration", function(x) standardGeneric("as.nanoduration"))

--- a/R/nanoduration.R
+++ b/R/nanoduration.R
@@ -348,6 +348,31 @@ setMethod("+", c("nanoival", "nanoduration"),
           function(e1, e2) {
               new("nanoival", nanoival_plus_impl(e1, e2))
           })
+##' @rdname nanoduration
+setMethod("-", c("nanoival", "nanoduration"),
+          function(e1, e2) {
+              new("nanoival", nanoival_plus_impl(e1, -e2))
+          })
+##' @rdname nanoduration
+setMethod("+", c("nanoduration", "nanoival"),
+          function(e1, e2) {
+              new("nanoival", nanoival_plus_impl(e2, e1))
+          })
+##' @rdname nanoduration
+setMethod("+", c("nanoival", "difftime"),
+          function(e1, e2) {
+              new("nanoival", nanoival_plus_impl(e1, as.nanoduration(e2)))
+          })
+##' @rdname nanoduration
+setMethod("-", c("nanoival", "difftime"),
+          function(e1, e2) {
+              new("nanoival", nanoival_plus_impl(e1, -as.nanoduration(e2)))
+          })
+##' @rdname nanoduration
+setMethod("+", c("difftime", "nanoival"),
+          function(e1, e2) {
+              new("nanoival", nanoival_plus_impl(e2, as.nanoduration(e1)))
+          })
 
 ##' @noRd
 setMethod("+", c("ANY", "nanoduration"),

--- a/inst/tinytest/test_nanoduration.R
+++ b/inst/tinytest/test_nanoduration.R
@@ -634,3 +634,13 @@ expect_identical(nt + dt_1sec, as.nanotime("2010-10-10 12:23:24.123456789 UTC"))
 expect_identical(dt_1sec + nt, as.nanotime("2010-10-10 12:23:24.123456789 UTC"))
 expect_identical(nt - dt_1sec, as.nanotime("2010-10-10 12:23:22.123456789 UTC"))
 expect_identical(nd_1sec + nt, as.nanotime("2010-10-10 12:23:24.123456789 UTC"))
+
+savedFormat <- options()$nanotimeFormat
+options(nanotimeFormat="%Y-%m-%d %H:%M:%S")
+ni <- as.nanoival("+2013-01-04 15:00:00 -> 2013-01-04 17:00:00-")
+expect_identical(ni + dt_1sec, as.nanoival("+2013-01-04 15:00:01 -> 2013-01-04 17:00:01-"))
+expect_identical(dt_1sec + ni, as.nanoival("+2013-01-04 15:00:01 -> 2013-01-04 17:00:01-"))
+expect_identical(nd_1sec + ni, as.nanoival("+2013-01-04 15:00:01 -> 2013-01-04 17:00:01-"))
+expect_identical(ni - dt_1sec, as.nanoival("+2013-01-04 14:59:59 -> 2013-01-04 16:59:59-"))
+expect_identical(ni - nd_1sec, as.nanoival("+2013-01-04 14:59:59 -> 2013-01-04 16:59:59-"))
+options(nanotimeFormat=savedFormat)

--- a/inst/tinytest/test_nanoduration.R
+++ b/inst/tinytest/test_nanoduration.R
@@ -626,3 +626,7 @@ dt_1sec <- as.difftime(1, units = "secs")
 nd_1sec <- nanoduration(seconds = 1L)
 expect_identical((dt_1sec - (dt_1sec + (nd_1sec - dt_1sec))) + dt_1sec,
 		 nanoduration(seconds = 1L))
+		 
+nt <- as.nanotime("2010-10-10 12:23:23.123456789 UTC")
+expect_identical((nd_1sec + (dt_1sec + (nt - dt_1sec))) + dt_1sec,
+                 as.nanotime("2010-10-10 12:23:25.123456789 UTC"))

--- a/inst/tinytest/test_nanoduration.R
+++ b/inst/tinytest/test_nanoduration.R
@@ -621,3 +621,8 @@ expect_identical(as.nanoduration(as.difftime(2.5, units = "secs")),
                  nanoduration(seconds = 2, nanoseconds = 5e8))
 expect_identical(as.nanoduration(as.difftime(2, units = "hours")),
                  nanoduration(hours = 2))
+                 
+dt_1sec <- as.difftime(1, units = "secs")
+nd_1sec <- nanoduration(seconds = 1L)
+expect_identical((dt_1sec - (dt_1sec + (nd_1sec - dt_1sec))) + dt_1sec,
+		 nanoduration(seconds = 1L))

--- a/inst/tinytest/test_nanoduration.R
+++ b/inst/tinytest/test_nanoduration.R
@@ -624,9 +624,13 @@ expect_identical(as.nanoduration(as.difftime(2, units = "hours")),
                  
 dt_1sec <- as.difftime(1, units = "secs")
 nd_1sec <- nanoduration(seconds = 1L)
-expect_identical((dt_1sec - (dt_1sec + (nd_1sec - dt_1sec))) + dt_1sec,
-		 nanoduration(seconds = 1L))
+expect_identical(dt_1sec + nd_1sec, nanoduration(seconds = 2L))
+expect_identical(nd_1sec + dt_1sec, nanoduration(seconds = 2L))
+expect_identical(dt_1sec - nd_1sec, nanoduration(seconds = 0L))
+expect_identical(nd_1sec - dt_1sec, nanoduration(seconds = 0L))
 		 
 nt <- as.nanotime("2010-10-10 12:23:23.123456789 UTC")
-expect_identical((nd_1sec + (dt_1sec + (nt - dt_1sec))) + dt_1sec,
-                 as.nanotime("2010-10-10 12:23:25.123456789 UTC"))
+expect_identical(nt + dt_1sec, as.nanotime("2010-10-10 12:23:24.123456789 UTC"))
+expect_identical(dt_1sec + nt, as.nanotime("2010-10-10 12:23:24.123456789 UTC"))
+expect_identical(nt - dt_1sec, as.nanotime("2010-10-10 12:23:22.123456789 UTC"))
+expect_identical(nd_1sec + nt, as.nanotime("2010-10-10 12:23:24.123456789 UTC"))

--- a/man/nanoduration.Rd
+++ b/man/nanoduration.Rd
@@ -38,6 +38,7 @@
 \alias{-,nanoduration,difftime-method}
 \alias{-,nanoduration,ANY-method}
 \alias{-,nanotime,nanoduration-method}
+\alias{-,nanotime,difftime-method}
 \alias{-,integer64,nanoduration-method}
 \alias{-,integer,nanoduration-method}
 \alias{-,numeric,nanoduration-method}
@@ -49,6 +50,9 @@
 \alias{+,nanoduration,numeric-method}
 \alias{+,nanoduration,difftime-method}
 \alias{+,nanotime,nanoduration-method}
+\alias{+,nanotime,difftime-method}
+\alias{+,nanoduration,nanotime-method}
+\alias{+,difftime,nanotime-method}
 \alias{+,nanoival,nanoduration-method}
 \alias{+,integer64,nanoduration-method}
 \alias{+,numeric,nanoduration-method}
@@ -125,6 +129,8 @@ nanoduration(hours = 0L, minutes = 0L, seconds = 0L, nanoseconds = 0L)
 
 \S4method{-}{nanotime,nanoduration}(e1, e2)
 
+\S4method{-}{nanotime,difftime}(e1, e2)
+
 \S4method{-}{integer64,nanoduration}(e1, e2)
 
 \S4method{-}{integer,nanoduration}(e1, e2)
@@ -146,6 +152,12 @@ nanoduration(hours = 0L, minutes = 0L, seconds = 0L, nanoseconds = 0L)
 \S4method{+}{nanoduration,difftime}(e1, e2)
 
 \S4method{+}{nanotime,nanoduration}(e1, e2)
+
+\S4method{+}{nanotime,difftime}(e1, e2)
+
+\S4method{+}{nanoduration,nanotime}(e1, e2)
+
+\S4method{+}{difftime,nanotime}(e1, e2)
 
 \S4method{+}{nanoival,nanoduration}(e1, e2)
 

--- a/man/nanoduration.Rd
+++ b/man/nanoduration.Rd
@@ -35,20 +35,24 @@
 \alias{-,nanoduration,integer64-method}
 \alias{-,nanoduration,integer-method}
 \alias{-,nanoduration,numeric-method}
+\alias{-,nanoduration,difftime-method}
 \alias{-,nanoduration,ANY-method}
 \alias{-,nanotime,nanoduration-method}
 \alias{-,integer64,nanoduration-method}
 \alias{-,integer,nanoduration-method}
 \alias{-,numeric,nanoduration-method}
+\alias{-,difftime,nanoduration-method}
 \alias{-,ANY,nanoduration-method}
 \alias{+,nanoduration,ANY-method}
 \alias{+,nanoduration,nanoduration-method}
 \alias{+,nanoduration,integer64-method}
 \alias{+,nanoduration,numeric-method}
+\alias{+,nanoduration,difftime-method}
 \alias{+,nanotime,nanoduration-method}
 \alias{+,nanoival,nanoduration-method}
 \alias{+,integer64,nanoduration-method}
 \alias{+,numeric,nanoduration-method}
+\alias{+,difftime,nanoduration-method}
 \alias{*,nanoduration,numeric-method}
 \alias{*,nanoduration,integer64-method}
 \alias{*,numeric,nanoduration-method}
@@ -115,6 +119,8 @@ nanoduration(hours = 0L, minutes = 0L, seconds = 0L, nanoseconds = 0L)
 
 \S4method{-}{nanoduration,numeric}(e1, e2)
 
+\S4method{-}{nanoduration,difftime}(e1, e2)
+
 \S4method{-}{nanoduration,ANY}(e1, e2)
 
 \S4method{-}{nanotime,nanoduration}(e1, e2)
@@ -124,6 +130,8 @@ nanoduration(hours = 0L, minutes = 0L, seconds = 0L, nanoseconds = 0L)
 \S4method{-}{integer,nanoduration}(e1, e2)
 
 \S4method{-}{numeric,nanoduration}(e1, e2)
+
+\S4method{-}{difftime,nanoduration}(e1, e2)
 
 \S4method{-}{ANY,nanoduration}(e1, e2)
 
@@ -135,6 +143,8 @@ nanoduration(hours = 0L, minutes = 0L, seconds = 0L, nanoseconds = 0L)
 
 \S4method{+}{nanoduration,numeric}(e1, e2)
 
+\S4method{+}{nanoduration,difftime}(e1, e2)
+
 \S4method{+}{nanotime,nanoduration}(e1, e2)
 
 \S4method{+}{nanoival,nanoduration}(e1, e2)
@@ -142,6 +152,8 @@ nanoduration(hours = 0L, minutes = 0L, seconds = 0L, nanoseconds = 0L)
 \S4method{+}{integer64,nanoduration}(e1, e2)
 
 \S4method{+}{numeric,nanoduration}(e1, e2)
+
+\S4method{+}{difftime,nanoduration}(e1, e2)
 
 \S4method{*}{nanoduration,numeric}(e1, e2)
 

--- a/man/nanoduration.Rd
+++ b/man/nanoduration.Rd
@@ -54,6 +54,11 @@
 \alias{+,nanoduration,nanotime-method}
 \alias{+,difftime,nanotime-method}
 \alias{+,nanoival,nanoduration-method}
+\alias{-,nanoival,nanoduration-method}
+\alias{+,nanoduration,nanoival-method}
+\alias{+,nanoival,difftime-method}
+\alias{-,nanoival,difftime-method}
+\alias{+,difftime,nanoival-method}
 \alias{+,integer64,nanoduration-method}
 \alias{+,numeric,nanoduration-method}
 \alias{+,difftime,nanoduration-method}
@@ -160,6 +165,16 @@ nanoduration(hours = 0L, minutes = 0L, seconds = 0L, nanoseconds = 0L)
 \S4method{+}{difftime,nanotime}(e1, e2)
 
 \S4method{+}{nanoival,nanoduration}(e1, e2)
+
+\S4method{-}{nanoival,nanoduration}(e1, e2)
+
+\S4method{+}{nanoduration,nanoival}(e1, e2)
+
+\S4method{+}{nanoival,difftime}(e1, e2)
+
+\S4method{-}{nanoival,difftime}(e1, e2)
+
+\S4method{+}{difftime,nanoival}(e1, e2)
 
 \S4method{+}{integer64,nanoduration}(e1, e2)
 


### PR DESCRIPTION
Adds the following S4 methods:

    * nanoduration() + difftime()
    * difftime() + nanoduration()
    * nanoduration() - difftime()
    * difftime - nanoduration()
    * nanotime() + difftime()
    * difftime() + nanotime()
    * nanotime() - difftime()
    * nanoduration() + nanotime() (arguably missing S4 method)

closes #107, closes #108
