### PR TITLE
No longer set a default compilation standard

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2023-03-12  Dirk Eddelbuettel  <edd@debian.org>
+
+	* src/Makevars: No longer set compilation standard
+	* src/Makevars.win: Idem
+	* src/Makevars.ucrt: Idem
+
 2022-12-06  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Roll minor version

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,7 @@
 2023-03-12  Dirk Eddelbuettel  <edd@debian.org>
 
+	* DESCRIPTION (Version, Date): Roll minor version
+
 	* src/Makevars: No longer set compilation standard
 	* src/Makevars.win: Idem
 	* src/Makevars.ucrt: Idem

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: nanotime
 Type: Package
 Title: Nanosecond-Resolution Time Support for R
-Version: 0.3.7.1
-Date: 2022-12-06
+Version: 0.3.7.2
+Date: 2023-03-12
 Author: Dirk Eddelbuettel and Leonardo Silvestri
 Maintainer: Dirk Eddelbuettel <edd@debian.org>
 Description: Full 64-bit resolution date and time functionality with

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -3,6 +3,12 @@
 \newcommand{\ghpr}{\href{https://github.com/eddelbuettel/nanotime/pull/#1}{##1}}
 \newcommand{\ghit}{\href{https://github.com/eddelbuettel/nanotime/issues/#1}{##1}}
 
+\section{Changes in version 0.3.8 (2023-xx-yy)}{
+  \itemize{
+    \item Time format documentation now has a reference to \pkg{RcppCCTZ}
+  }
+}
+
 \section{Changes in version 0.3.7 (2022-10-23)}{
   \itemize{
     \item Update mkdocs for material docs generator (Dirk in \ghpr{102})

--- a/src/Makevars
+++ b/src/Makevars
@@ -1,5 +1,3 @@
-## We want C++11 
-CXX_STD = CXX11
 
 ## We need headers from our package, the directory is not automatically included
 PKG_CXXFLAGS = -I../inst/include

--- a/src/Makevars.ucrt
+++ b/src/Makevars.ucrt
@@ -1,5 +1,3 @@
-## We want C++11 
-CXX_STD = CXX11
 
 ## We need headers from our package, the directory is not automatically included
 PKG_CXXFLAGS = -I../inst/include -mno-ms-bitfields -D_POSIX_THREAD_SAFE_FUNCTIONS

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,5 +1,3 @@
-## We want C++11 
-CXX_STD = CXX11
 
 ## We need headers from our package, the directory is not automatically included
 PKG_CXXFLAGS = -I../inst/include -mno-ms-bitfields


### PR DESCRIPTION
R now nags when C++11 is set, and recomments to let the R version default (which is C++14 since R 4.1.0 and may soon be C++17) govern this.  Our package is fairly conservative in its use of language idioms so this should not be an issue.