### PR TITLE
'as.Date' forces use of 'tz' and can handle 'tz' as a vector; closes …

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2023-09-22  Dirk Eddelbuettel  <edd@debian.org>
+
+	* R/nanotime.R: Provide default UTC timezone in 'as.Date()'
+	* tests/simpleTests.R: Adjist a test accordingly
+	* inst/tinytest/test_nanotime.R: Idem
+
 2023-09-21  Leonardo Silvestri  <lsilvestri@ztsdb.org>
 
 	* DESCRIPTION (Version, Date): Roll minor version

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2023-09-26  Leonardo Silvestri  <lsilvestri@ztsdb.org>
+
+	* R/nanotime.R: Further refinement for default UTC timezone
+	* inst/tinytest/test_nanotime.R: Idem
+
 2023-09-22  Dirk Eddelbuettel  <edd@debian.org>
 
 	* R/nanotime.R: Provide default UTC timezone in 'as.Date()'
@@ -7,7 +12,7 @@
 2023-09-21  Leonardo Silvestri  <lsilvestri@ztsdb.org>
 
 	* DESCRIPTION (Version, Date): Roll minor version
-	* R/nanotime.R: fixed 'as.Date' to force use of timezone and to
+	* R/nanotime.R: Fixed 'as.Date' to force use of timezone and to
 	allow the timezone argument to be a vector
 
 2023-07-11  Dirk Eddelbuettel  <edd@debian.org>

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2023-09-21  Leonardo Silvestri  <lsilvestri@ztsdb.org>
+
+	* DESCRIPTION (Version, Date): Roll minor version
+	* R/nanotime.R: fixed 'as.Date' to force use of timezone and to
+	allow the timezone argument to be a vector
+
 2023-07-11  Dirk Eddelbuettel  <edd@debian.org>
 
 	* README.md: Add r-universe badge

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: nanotime
 Type: Package
 Title: Nanosecond-Resolution Time Support for R
-Version: 0.3.7.3
-Date: 2023-07-06
+Version: 0.3.7.4
+Date: 2023-09-21
 Author: Dirk Eddelbuettel and Leonardo Silvestri
 Maintainer: Dirk Eddelbuettel <edd@debian.org>
 Description: Full 64-bit resolution date and time functionality with

--- a/R/nanotime.R
+++ b/R/nanotime.R
@@ -339,6 +339,9 @@ setAs("nanotime", "POSIXlt", function(from) as.POSIXlt.nanotime(from))
 ##' @rdname nanotime
 as.Date.nanotime <- function(x, ...) {
     args <- list(...)
+    if (length(args) == 0) {
+        args <- list(tz="UTC")
+    }
     if (!("tz" %in% names(args))) {
         stop("'as.Date' call is missing mandatory timezone argument 'tz'")        
     }

--- a/R/nanotime.R
+++ b/R/nanotime.R
@@ -338,7 +338,13 @@ setAs("nanotime", "POSIXlt", function(from) as.POSIXlt.nanotime(from))
 
 ##' @rdname nanotime
 as.Date.nanotime <- function(x, ...) {
-    as.Date(as.POSIXct(x))
+    args <- list(...)
+    if (!("tz" %in% names(args))) {
+        stop("'as.Date' call is missing mandatory timezone argument 'tz'")        
+    }
+    as.Date(ISOdate(year = nano_year(x, args$tz),
+                    month = nano_month(x, args$tz),
+                    day = nano_mday(x, args$tz)))
 }
 
 setAs("nanotime", "Date", function(from) as.Date(as.POSIXct(from)))

--- a/R/nanotime.R
+++ b/R/nanotime.R
@@ -338,16 +338,18 @@ setAs("nanotime", "POSIXlt", function(from) as.POSIXlt.nanotime(from))
 
 ##' @rdname nanotime
 as.Date.nanotime <- function(x, ...) {
-    args <- list(...)
-    if (length(args) == 0) {
-        args <- list(tz="UTC")
-    }
+    arguments <- list(...)
     if (!("tz" %in% names(args))) {
-        stop("'as.Date' call is missing mandatory timezone argument 'tz'")        
+        arguments <- c(arguments, list(tz="UTC"))
     }
-    as.Date(ISOdate(year = nano_year(x, args$tz),
-                    month = nano_month(x, args$tz),
-                    day = nano_mday(x, args$tz)))
+    other_args <- setdiff(names(arguments), list('x', 'tz'))
+    if (length(other_args) > 0) {
+        stop(paste("'as.Date' called with arguments other than 'tz': ",
+                   paste0("'", other_args, "'", collapse=", ")))
+    }
+    as.Date(ISOdate(year = nano_year(x, arguments$tz),
+                    month = nano_month(x, arguments$tz),
+                    day = nano_mday(x, arguments$tz)))
 }
 
 setAs("nanotime", "Date", function(from) as.Date(as.POSIXct(from)))

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -11,6 +11,8 @@
     \item New \code{accurate} parameter for conversion from \code{POSIXct} to
     \code{nanotime} (Davor Josipovic and Leonardo in \ghpr{116} closing
     \ghit{115})
+    \item The \code{as.Date()} function is now vectorized and can take a TZ
+    argument (Leonardo and Dirk in \ghpr{119} closing \ghit{118})
   }
 }
 

--- a/inst/tinytest/test_nanotime.R
+++ b/inst/tinytest/test_nanotime.R
@@ -344,8 +344,15 @@ expect_equal(p, as.POSIXct("1970-01-01 00:00:00", tz="UTC"), check.tzone=FALSE)
 options(nanotimeTz=oldTz)
 
 ##test_as_Date <- function() {
-expect_identical(as.Date(nanotime(0)), as.Date("1970-01-01"))
-
+## test scalar
+nanotime_scalar <- nanotime("2023-09-21T22:00:00 America/New_York")
+expect_identical(as.Date(nanotime_scalar, tz="UTC"), as.Date("2023-09-22"))
+## test vector
+nanotime_vec <- rep(nanotime("2023-09-21T22:00:00 America/New_York"), 2)
+tz_vec <- c("UTC", "America/New_York")
+expect_identical(as.Date(nanotime_vec, tz=tz_vec), as.Date(c("2023-09-22", "2023-09-21")))
+## test missing argument 'tz':
+expect_error(as.Date(nanotime_vec), "'as.Date' call is missing mandatory timezone argument 'tz'")
 
 ## c, subset, subassign and binds
 ##test_c <- function() {

--- a/inst/tinytest/test_nanotime.R
+++ b/inst/tinytest/test_nanotime.R
@@ -351,8 +351,8 @@ expect_identical(as.Date(nanotime_scalar, tz="UTC"), as.Date("2023-09-22"))
 nanotime_vec <- rep(nanotime("2023-09-21T22:00:00 America/New_York"), 2)
 tz_vec <- c("UTC", "America/New_York")
 expect_identical(as.Date(nanotime_vec, tz=tz_vec), as.Date(c("2023-09-22", "2023-09-21")))
-## test missing argument 'tz':
-expect_error(as.Date(nanotime_vec), "'as.Date' call is missing mandatory timezone argument 'tz'")
+## test missing argument 'tz': now UTC filled in
+expect_silent(as.Date(nanotime_vec))
 
 ## c, subset, subassign and binds
 ##test_c <- function() {

--- a/inst/tinytest/test_nanotime.R
+++ b/inst/tinytest/test_nanotime.R
@@ -353,6 +353,11 @@ tz_vec <- c("UTC", "America/New_York")
 expect_identical(as.Date(nanotime_vec, tz=tz_vec), as.Date(c("2023-09-22", "2023-09-21")))
 ## test missing argument 'tz': now UTC filled in
 expect_silent(as.Date(nanotime_vec))
+expect_identical(as.Date(nanotime_vec), as.Date(nanotime_vec, tz="UTC"))
+## test exception for extraneous argument:
+expect_error(as.Date(nanotime_vec, y=2, z=3), "'as.Date' called with arguments other than 'tz':  'y', 'z'")
+expect_silent(as.Date(x=nanotime_vec))  # check we can still name 'x' without an exception
+
 
 ## c, subset, subassign and binds
 ##test_c <- function() {

--- a/tests/simpleTests.R
+++ b/tests/simpleTests.R
@@ -34,6 +34,7 @@ as.POSIXct(x)
 as.POSIXct(x+1000)
 as.POSIXlt(x)
 as.POSIXlt(x+1000)
+as.Date(x)
 as.Date(x, tz="UTC")
 options("digits.secs"=od)
 

--- a/tests/simpleTests.R
+++ b/tests/simpleTests.R
@@ -34,7 +34,7 @@ as.POSIXct(x)
 as.POSIXct(x+1000)
 as.POSIXlt(x)
 as.POSIXlt(x+1000)
-as.Date(x)
+as.Date(x, tz="UTC")
 options("digits.secs"=od)
 
 


### PR DESCRIPTION
…#118

I think forcing the use of 'tz' is essential; we didn't enforce it before, so it would revert to the default way that `POSIXct` infers timezone which is exactly what we set out not to do in `nanotime` because we wanted timezones to always be explicit. I think it reduces a lot the subtle errors that invariable creep in when functions automatically assume something about timezones.

The other improvement here of course is that 'tz' can now be a vector.