### PR TITLE
nanoduration / nanoduration returns double instead of integer64

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,8 @@
 2024-05-24  Leonardo Silvestri  <lsilvestr@ztsdb.org>
+	* R/nanoduration.R: duration divided by duration returns double
+	* inst/tinytest/test_nanoduration.R: additional test for the above
+
+2024-05-24  Leonardo Silvestri  <lsilvestr@ztsdb.org>
 
 	* inst/include/nanotime/utilities.hpp: Use interface function Rf_asS4
 	instead of internal SET_S4_OBJECT

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,8 +1,7 @@
 2024-05-24  Leonardo Silvestri  <lsilvestr@ztsdb.org>
+
 	* R/nanoduration.R: duration divided by duration returns double
 	* inst/tinytest/test_nanoduration.R: additional test for the above
-
-2024-05-24  Leonardo Silvestri  <lsilvestr@ztsdb.org>
 
 	* inst/include/nanotime/utilities.hpp: Use interface function Rf_asS4
 	instead of internal SET_S4_OBJECT

--- a/R/nanoduration.R
+++ b/R/nanoduration.R
@@ -439,7 +439,7 @@ setMethod("*", c("ANY", "nanoduration"),
 ##' @rdname nanoduration
 setMethod("/", c("nanoduration", "nanoduration"),
           function(e1, e2) {
-              as.integer64(S3Part(e1, strictS3=TRUE) / S3Part(e2, strictS3=TRUE))
+              S3Part(e1, strictS3=TRUE) / S3Part(e2, strictS3=TRUE)
           })
 ##' @rdname nanoduration
 setMethod("/", c("nanoduration", "integer64"),

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -3,7 +3,7 @@
 \newcommand{\ghpr}{\href{https://github.com/eddelbuettel/nanotime/pull/#1}{##1}}
 \newcommand{\ghit}{\href{https://github.com/eddelbuettel/nanotime/issues/#1}{##1}}
 
-\section{Changes in version 0.3.8 (2023-07-xx)}{
+\section{Changes in version 0.3.8 (2024-xx-xx)}{
   \itemize{
     \item Time format documentation now has a reference to \pkg{RcppCCTZ}
     \item The package no longer sets a default C++ compilation standard (Dirk
@@ -13,6 +13,10 @@
     \ghit{115})
     \item The \code{as.Date()} function is now vectorized and can take a TZ
     argument (Leonardo and Dirk in \ghpr{119} closing \ghit{118})
+    \item Use of internal function \code{SET_S4_OBJECT} has been replaced by
+    API function \code{Rf_asS4} (Leonardo in \ghpr{121} closing \ghit{120})
+    \item An \code{nanoduration} / \code{nanoduration} expression now returns
+    a double (Leonardo in \ghpr{122} closing \ghit{117})
   }
 }
 

--- a/inst/tinytest/test_nanoduration.R
+++ b/inst/tinytest/test_nanoduration.R
@@ -301,7 +301,10 @@ expect_error(1.5 / as.nanoduration("00:01:00"), "invalid operand types")
 expect_error(as.nanoduration("1:00:00") / "a", "invalid operand types")
 
 ##test_nanoduration_div_nanoduration <- function() {
-expect_identical(as.nanoduration(6) / as.nanoduration(2), as.integer64(3))
+expect_identical(as.nanoduration(6) / as.nanoduration(2), 3.0)
+
+##test_nanoduration_div_nanoduration <- function() {
+expect_identical(as.nanoduration(7) / as.nanoduration(2), 3.5)
 
 
 ## unary


### PR DESCRIPTION
Fixes #117