### PR TITLE
Skip two tests on arm64, add macOS to matrix (fixes #128)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         include:
-          #- {os: macOS-latest}
+          - {os: macOS-latest}
           - {os: ubuntu-latest}
 
     runs-on: ${{ matrix.os }}

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2024-06-20  Dirk Eddelbuettel  <edd@debian.org>
+
+	* inst/tinytest/test_nanotime.R: Condition two tests to not run on arm64
+
+	* .github/workflows/ci.yaml (jobs): Add macOS-latest back to matrix
+
 2024-06-19  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Release 0.3.8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: nanotime
 Type: Package
 Title: Nanosecond-Resolution Time Support for R
-Version: 0.3.8
-Date: 2024-06-19
+Version: 0.3.8.1
+Date: 2024-06-20
 Author: Dirk Eddelbuettel and Leonardo Silvestri
 Maintainer: Dirk Eddelbuettel <edd@debian.org>
 Description: Full 64-bit resolution date and time functionality with

--- a/inst/tinytest/test_nanotime.R
+++ b/inst/tinytest/test_nanotime.R
@@ -8,6 +8,7 @@ options(digits=7)                       # needed for error message of 0.3333333 
 expect_equal_numeric <- function(x,y,...) expect_equal(as.numeric(x), as.numeric(y), ...)
 
 isSolaris <- Sys.info()[["sysname"]] == "SunOS"
+isArm64 <- Sys.info()[["machine"]] == "arm64"
 
 ## nanotime constructors
 ##test_nanotime_generic <- function() {
@@ -140,11 +141,11 @@ expect_identical(as.nanotime(p), nanotime("1970-01-01T00:00:00.000000000-05:00")
 ## This one should break if multiplying the double by 1E9 directly
 ## without considering the integer and fraction parts separately.
 p <- as.POSIXct(as.numeric('0x1.91f18e4d0065p+30'), origin = '1970-01-01')
-expect_identical(p, as.POSIXct(as.nanotime(p)))
+if (!isArm64) expect_identical(p, as.POSIXct(as.nanotime(p)))
 
 ## This one is negative, making sure that negative doubles are also consistent.
 p <- as.POSIXct(as.numeric('-0x1.c6e8c4d077ae4p+30'), origin = '1970-01-01')
-expect_identical(p, as.POSIXct(as.nanotime(p)))
+if (!isArm64) expect_identical(p, as.POSIXct(as.nanotime(p)))
 
 ## with the 'accurate' parameter set to FALSE, the round trip should not be equal:
 p <- as.POSIXct(as.numeric('0x1.91f18e4d0065p+30'), origin = '1970-01-01')


### PR DESCRIPTION
As described in #128 and seen at CRAN, arm64 balks at two round-robin tests for POSIXct conversion.  A meta-question is if we should maybe error on that platform if `accurate` is TRUE?  Or is that too harsh?

