### PR TITLE
Retire tests for solaris

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,8 @@
 2024-06-22  Dirk Eddelbuettel  <edd@debian.org>
 
-	* inst/tinytest/test_nanotime.R: Retire test for Solaris 
+	* DESCRIPTION (Version, Date): Roll minor version and date
+
+	* inst/tinytest/test_nanotime.R: Retire test for Solaris
 	* inst/tinytest/test_nanoperiod.R: Idem
 	* inst/tinytest/test_nanoival.R: Idem
 	* inst/tinytest/test_zoo.R: Idem

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2024-06-22  Dirk Eddelbuettel  <edd@debian.org>
+
+	* inst/tinytest/test_nanotime.R: Retire test for Solaris 
+	* inst/tinytest/test_nanoperiod.R: Idem
+	* inst/tinytest/test_nanoival.R: Idem
+	* inst/tinytest/test_zoo.R: Idem
+
 2024-06-21  Dirk Eddelbuettel  <edd@debian.org>
 
  	* DESCRIPTION (Version, Date): Release 0.3.9

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: nanotime
 Type: Package
 Title: Nanosecond-Resolution Time Support for R
-Version: 0.3.9
-Date: 2024-06-21
+Version: 0.3.9.1
+Date: 2024-06-22
 Author: Dirk Eddelbuettel and Leonardo Silvestri
 Maintainer: Dirk Eddelbuettel <edd@debian.org>
 Description: Full 64-bit resolution date and time functionality with

--- a/inst/tinytest/test_nanoival.R
+++ b/inst/tinytest/test_nanoival.R
@@ -1,7 +1,6 @@
 library(nanotime)
 suppressMessages(library(bit64))
 
-isSolaris <- Sys.info()[["sysname"]] == "SunOS"
 extended_tests <- Sys.getenv("CI", "") != ""
 
 savedFormat <- NULL
@@ -37,27 +36,25 @@ expect_identical(nanoival.start(ni),  c(a=nanotime("2013-01-01 00:00:00"),
     expect_identical(nanoival.sopen(ni), c(a=FALSE, b=FALSE, c=TRUE, d=TRUE)) &
     expect_identical(nanoival.eopen(ni), c(a=TRUE, b=FALSE, c=TRUE, d=FALSE))
 
-if (!isSolaris) {
-    expect_identical(length(as.nanoival(vector("character", 0))), 0L)
-    expect_identical(as.nanoival("-2013-01-01 00:00:00 America/New_York -> 2014-01-01 00:00:00 America/New_York+"),
-                     nanoival(nanotime("2013-01-01 00:00:00 America/New_York"),
-                              nanotime("2014-01-01 00:00:00 America/New_York"), TRUE, FALSE))
+expect_identical(length(as.nanoival(vector("character", 0))), 0L)
+expect_identical(as.nanoival("-2013-01-01 00:00:00 America/New_York -> 2014-01-01 00:00:00 America/New_York+"),
+                 nanoival(nanotime("2013-01-01 00:00:00 America/New_York"),
+                          nanotime("2014-01-01 00:00:00 America/New_York"), TRUE, FALSE))
 
-    ## test warning when we double specify the timezone:
-    expect_error(as.nanoival("-2013-01-01 00:00:00 America/New_York -> 2014-01-01 00:00:00+00:00+", tz="Europe/London"),
-                 "timezone is specified twice: in the string and as an argument")
+## test warning when we double specify the timezone:
+expect_error(as.nanoival("-2013-01-01 00:00:00 America/New_York -> 2014-01-01 00:00:00+00:00+", tz="Europe/London"),
+             "timezone is specified twice: in the string and as an argument")
 
-    ##test_as.nanoival_vector_fail <- function() {
-    expect_error(as.nanoival("-2013-01-01 00:00:00 -> 2014-01-01 00:00:00"), "`nanoival` must end with '\\+' or '-'")
-    expect_error(as.nanoival("2013-01-01 00:00:00 -> 2014-01-01 00:00:00-"), "`nanoival` must start with '\\+' or '-'") 
-    expect_error(as.nanoival("+2013-01-01 00:00:00 $$ 2014-01-01 00:00:00-"), "Parse error on 2013-01-01 00:00:00 \\$\\$ 2014-01-01 00:00:00")
-    expect_error(as.nanoival("+2013-01-01 00:00:00 -> 2014-01-01 00:00:00- "), "`nanoival` must end with '\\+' or '-'")
-    expect_error(as.nanoival("+2013-01-01 00:00:00 -> 2014-01-01 00:00:00a"), "`nanoival` must end with '\\+' or '-'")
-    expect_error(as.nanoival("+2013-01-01 00:00:00 America/New_York -> 2014-01-01 00:00:00 America/New_York %%"), "`nanoival` must end with '\\+' or '-'")
-    expect_error(as.nanoival("+2013-01-01 00:00:00 America/New_York -> 2014-01-01 00:00:00 America/New_York + "), "`nanoival` must end with '\\+' or '-'")
-    expect_error(as.nanoival("-2013-01-01 00:00:00 America/New_York -> 2014-01-01 00:00:00 America/New_YYork+"),
-                 "Cannot retrieve timezone")
-}
+##test_as.nanoival_vector_fail <- function() {
+expect_error(as.nanoival("-2013-01-01 00:00:00 -> 2014-01-01 00:00:00"), "`nanoival` must end with '\\+' or '-'")
+expect_error(as.nanoival("2013-01-01 00:00:00 -> 2014-01-01 00:00:00-"), "`nanoival` must start with '\\+' or '-'")
+expect_error(as.nanoival("+2013-01-01 00:00:00 $$ 2014-01-01 00:00:00-"), "Parse error on 2013-01-01 00:00:00 \\$\\$ 2014-01-01 00:00:00")
+expect_error(as.nanoival("+2013-01-01 00:00:00 -> 2014-01-01 00:00:00- "), "`nanoival` must end with '\\+' or '-'")
+expect_error(as.nanoival("+2013-01-01 00:00:00 -> 2014-01-01 00:00:00a"), "`nanoival` must end with '\\+' or '-'")
+expect_error(as.nanoival("+2013-01-01 00:00:00 America/New_York -> 2014-01-01 00:00:00 America/New_York %%"), "`nanoival` must end with '\\+' or '-'")
+expect_error(as.nanoival("+2013-01-01 00:00:00 America/New_York -> 2014-01-01 00:00:00 America/New_York + "), "`nanoival` must end with '\\+' or '-'")
+expect_error(as.nanoival("-2013-01-01 00:00:00 America/New_York -> 2014-01-01 00:00:00 America/New_YYork+"),
+             "Cannot retrieve timezone")
 
 expect_error(as.nanoival(aa, tz=list(1)), "argument 'tz' must be of type 'character'")
               
@@ -1353,10 +1350,9 @@ n1 <- nanotime(1)
 n2 <- nanotime(2)
 ni <- nanoival(n1, n2)
 prd <- as.nanoperiod("200y")
-if (!isSolaris) {
-    expect_warning(plus (ni, prd, "America/New_York"), "NAs produced by time overflow \\(remember that interval times are coded with 63 bits\\)")
-    expect_warning(minus(ni, prd, "America/New_York"), "NAs produced by time overflow \\(remember that interval times are coded with 63 bits\\)")
-}
+expect_warning(plus (ni, prd, "America/New_York"), "NAs produced by time overflow \\(remember that interval times are coded with 63 bits\\)")
+expect_warning(minus(ni, prd, "America/New_York"), "NAs produced by time overflow \\(remember that interval times are coded with 63 bits\\)")
+
 dur <- as.nanoduration(200*365*24*3600*1e9)
 expect_warning(ni + dur, "NAs produced by time overflow \\(remember that interval times are coded with 63 bits\\)")
 expect_warning(ni + dur, "NAs produced by time overflow \\(remember that interval times are coded with 63 bits\\)")
@@ -1389,12 +1385,11 @@ expect_identical(as.nanoival(aa), as(aa, "nanoival"))
 ## test seq:
 
 x <- as.nanoival("+2013-01-01 15:00:00 -> 2013-01-01 17:00:00-")
-if (!isSolaris) {
-    expect_identical(seq(x, by=as.nanoperiod("1m"), length.out=4, tz="America/New_York"),
-                     nanoival(seq(nanoival.start(x), by=as.nanoperiod("1m"), length.out=4, tz="America/New_York"),
-                              seq(nanoival.end(x),   by=as.nanoperiod("1m"), length.out=4, tz="America/New_York"),
-                              FALSE, TRUE))
-}
+expect_identical(seq(x, by=as.nanoperiod("1m"), length.out=4, tz="America/New_York"),
+                 nanoival(seq(nanoival.start(x), by=as.nanoperiod("1m"), length.out=4, tz="America/New_York"),
+                          seq(nanoival.end(x),   by=as.nanoperiod("1m"), length.out=4, tz="America/New_York"),
+                          FALSE, TRUE))
+
 y <- as.nanoival("+2013-01-04 15:00:00 -> 2013-01-04 17:00:00-")
 expect_identical(seq(x, y, by=as.nanoduration("24:00:00")),
                  nanoival(seq(nanoival.start(x), by=as.nanoperiod("1d"), length.out=4, tz="UTC"),

--- a/inst/tinytest/test_nanoperiod.R
+++ b/inst/tinytest/test_nanoperiod.R
@@ -4,8 +4,6 @@ suppressMessages({
     library(bit64)
 })
 
-isSolaris <- Sys.info()[["sysname"]] == "SunOS"
-
 ## constructors
 ##test_as.nanoperiod_character <- function() {
 p1 <- as.nanoperiod("1m1d")
@@ -476,193 +474,190 @@ pp <- c(as.nanoperiod(1:10), as.nanoperiod(11:20))
 expect_identical(pp, as.nanoperiod(1:20))
 
 
-if (!isSolaris) {
+## plus/minus with 'nanotime':
 
-    ## plus/minus with 'nanotime':
+##test_plus_nanotime_nanoperiod <- function() {
+nt <- nanotime("2018-01-01T05:00:00.000000000+00")
+p  <- c(p=as.nanoperiod("4m"))
+tz <- "America/New_York"
+expected <- c(p=nanotime("2018-05-01T00:00:00.000000000-04:00"))
+expect_identical(plus(nt, p, tz), expected)
 
-    ##test_plus_nanotime_nanoperiod <- function() {
-    nt <- nanotime("2018-01-01T05:00:00.000000000+00")
-    p  <- c(p=as.nanoperiod("4m"))
-    tz <- "America/New_York"
-    expected <- c(p=nanotime("2018-05-01T00:00:00.000000000-04:00"))
-    expect_identical(plus(nt, p, tz), expected)
+##test_plus_nanotime_nanoperiod_vector1 <- function() {
+nt <- nanotime("2018-01-01T05:00:00.000000000+00") + 1:10
+p  <- as.nanoperiod("4m")
+tz <- "America/New_York"
+expected <- nanotime("2018-05-01T00:00:00.000000000-04:00") + 1:10
+expect_identical(plus(nt, p, tz), expected)
 
-    ##test_plus_nanotime_nanoperiod_vector1 <- function() {
-    nt <- nanotime("2018-01-01T05:00:00.000000000+00") + 1:10
-    p  <- as.nanoperiod("4m")
-    tz <- "America/New_York"
-    expected <- nanotime("2018-05-01T00:00:00.000000000-04:00") + 1:10
-    expect_identical(plus(nt, p, tz), expected)
+##test_plus_nanotime_nanoperiod_vector2 <- function() {
+nt <- nanotime("2018-01-01T05:00:00.000000000+00")
+p  <- as.nanoperiod("4m") + 1:10
+tz <- "America/New_York"
+expected <- nanotime("2018-05-01T00:00:00.000000000-04:00") + 1:10
+expect_identical(plus(nt, p, tz), expected)
 
-    ##test_plus_nanotime_nanoperiod_vector2 <- function() {
-    nt <- nanotime("2018-01-01T05:00:00.000000000+00")
-    p  <- as.nanoperiod("4m") + 1:10
-    tz <- "America/New_York"
-    expected <- nanotime("2018-05-01T00:00:00.000000000-04:00") + 1:10
-    expect_identical(plus(nt, p, tz), expected)
+##test_plus_nanotime_nanoperiod_vector3 <- function() {
+nt <- nanotime("2018-01-01T05:00:00.000000000+00")
+p  <- as.nanoperiod("4m") + 1:10
+tz <- rep("America/New_York", 10)
+expected <- nanotime("2018-05-01T00:00:00.000000000-04:00") + 1:10
+expect_identical(plus(nt, p, tz), expected)
 
-    ##test_plus_nanotime_nanoperiod_vector3 <- function() {
-    nt <- nanotime("2018-01-01T05:00:00.000000000+00")
-    p  <- as.nanoperiod("4m") + 1:10
-    tz <- rep("America/New_York", 10)
-    expected <- nanotime("2018-05-01T00:00:00.000000000-04:00") + 1:10
-    expect_identical(plus(nt, p, tz), expected)
+##test_plus_nanoperiod_nanotime <- function() {
+nt <- nanotime("2018-01-01T05:00:00.000000000+00")
+p  <- c(p=as.nanoperiod("4m"))
+tz <- "America/New_York"
+expected <- c(p=nanotime("2018-05-01T00:00:00.000000000-04:00"))
+expect_identical(plus(p, nt, tz), expected)
 
-    ##test_plus_nanoperiod_nanotime <- function() {
-    nt <- nanotime("2018-01-01T05:00:00.000000000+00")
-    p  <- c(p=as.nanoperiod("4m"))
-    tz <- "America/New_York"
-    expected <- c(p=nanotime("2018-05-01T00:00:00.000000000-04:00"))
-    expect_identical(plus(p, nt, tz), expected)
+##test_minus_nanotime_nanoperiod <- function() {
+nt <- c(p1=nanotime("2018-05-01T00:00:00.000000000-04:00"))
+p  <- c(p2=as.nanoperiod("4m"))
+tz <- "America/New_York"
+expected <- c(p1=nanotime("2018-01-01T00:00:00.000000000-05:00"))
+expect_identical(minus(nt, p, tz), expected)
 
-    ##test_minus_nanotime_nanoperiod <- function() {
-    nt <- c(p1=nanotime("2018-05-01T00:00:00.000000000-04:00"))
-    p  <- c(p2=as.nanoperiod("4m"))
-    tz <- "America/New_York"
-    expected <- c(p1=nanotime("2018-01-01T00:00:00.000000000-05:00"))
-    expect_identical(minus(nt, p, tz), expected)
+##test_minus_nanoperiod_nanotime <- function() {
+nt <- nanotime("2018-05-01T00:00:00.000000000-04:00")
+p  <- as.nanoperiod("4m")
+tz <- "America/New_York"
+expect_error(minus(p, nt, tz), "operation not defined for 'nanoperiod' objects")
 
-    ##test_minus_nanoperiod_nanotime <- function() {
-    nt <- nanotime("2018-05-01T00:00:00.000000000-04:00")
-    p  <- as.nanoperiod("4m")
-    tz <- "America/New_York"
-    expect_error(minus(p, nt, tz), "operation not defined for 'nanoperiod' objects")
+## test the crossing of daylight saving time in both directions:
 
-    ## test the crossing of daylight saving time in both directions:
+## adding/subtracting a nanoperiod should not realign if doing so
+## crosses again a DST boundary:
 
-    ## adding/subtracting a nanoperiod should not realign if doing so
-    ## crosses again a DST boundary:
+## look at cases over the Spring boundary in America:
+nt <- as.nanotime("2020-03-08 01:45:30 America/New_York")
+p <- as.nanoperiod("00:30:00")
+tz <- "America/New_York"
+expected <- as.nanotime("2020-03-08 03:15:30 America/New_York")
+expect_identical(plus(nt, p, tz), expected)
 
-    ## look at cases over the Spring boundary in America:
-    nt <- as.nanotime("2020-03-08 01:45:30 America/New_York")
-    p <- as.nanoperiod("00:30:00")
-    tz <- "America/New_York"
-    expected <- as.nanotime("2020-03-08 03:15:30 America/New_York")
-    expect_identical(plus(nt, p, tz), expected)
+nt <- as.nanotime("2020-03-08 01:00:00 America/New_York")
+p <- as.nanoperiod("01:00:00")
+tz <- "America/New_York"
+expected <- as.nanotime("2020-03-08 03:00:00 America/New_York")
+expect_identical(plus(nt, p, tz), expected)
 
-    nt <- as.nanotime("2020-03-08 01:00:00 America/New_York")
-    p <- as.nanoperiod("01:00:00")
-    tz <- "America/New_York"
-    expected <- as.nanotime("2020-03-08 03:00:00 America/New_York")
-    expect_identical(plus(nt, p, tz), expected)
+nt <- as.nanotime("2020-03-08 03:15:30 America/New_York")
+p <- as.nanoperiod("00:30:00")
+tz <- "America/New_York"
+expected <- as.nanotime("2020-03-08 01:45:30 America/New_York")
+expect_identical(minus(nt, p, tz), expected)
 
-    nt <- as.nanotime("2020-03-08 03:15:30 America/New_York")
-    p <- as.nanoperiod("00:30:00")
-    tz <- "America/New_York"
-    expected <- as.nanotime("2020-03-08 01:45:30 America/New_York")
-    expect_identical(minus(nt, p, tz), expected)
+nt <- as.nanotime("2020-03-08 03:00:00 America/New_York")
+p <- as.nanoperiod("01:00:00")
+tz <- "America/New_York"
+expected <- as.nanotime("2020-03-08 01:00:00 America/New_York")
+expect_identical(minus(nt, p, tz), expected)
 
-    nt <- as.nanotime("2020-03-08 03:00:00 America/New_York")
-    p <- as.nanoperiod("01:00:00")
-    tz <- "America/New_York"
-    expected <- as.nanotime("2020-03-08 01:00:00 America/New_York")
-    expect_identical(minus(nt, p, tz), expected)
+## look at the cases over the Autumn boundary in America:
+nt <- as.nanotime("2020-11-01 01:45:30 America/New_York")
+p <- as.nanoperiod("00:30:00")
+tz <- "America/New_York"
+expected <- as.nanotime("2020-11-01 02:15:30 America/New_York")
+expect_identical(plus(nt, p, tz), expected)
 
-    ## look at the cases over the Autumn boundary in America:
-    nt <- as.nanotime("2020-11-01 01:45:30 America/New_York")
-    p <- as.nanoperiod("00:30:00")
-    tz <- "America/New_York"
-    expected <- as.nanotime("2020-11-01 02:15:30 America/New_York")
-    expect_identical(plus(nt, p, tz), expected)
+nt <- as.nanotime("2020-11-01 01:00:00 America/New_York")
+p <- as.nanoperiod("01:00:00")
+tz <- "America/New_York"
+expected <- as.nanotime("2020-11-01 02:00:00 America/New_York")
+expect_identical(plus(nt, p, tz), expected)
 
-    nt <- as.nanotime("2020-11-01 01:00:00 America/New_York")
-    p <- as.nanoperiod("01:00:00")
-    tz <- "America/New_York"
-    expected <- as.nanotime("2020-11-01 02:00:00 America/New_York")
-    expect_identical(plus(nt, p, tz), expected)
+nt <- as.nanotime("2020-11-01 02:15:30 America/New_York")
+p <- as.nanoperiod("00:30:00")
+tz <- "America/New_York"
+##expected <- as.nanotime("2020-11-01 01:45:30 America/New_York")  # ambiguous
+expected <- as.nanotime("2020-11-01 06:45:30+00:00")
+expect_identical(minus(nt, p, tz), expected)
 
-    nt <- as.nanotime("2020-11-01 02:15:30 America/New_York")
-    p <- as.nanoperiod("00:30:00")
-    tz <- "America/New_York"
-    ##expected <- as.nanotime("2020-11-01 01:45:30 America/New_York")  # ambiguous
-    expected <- as.nanotime("2020-11-01 06:45:30+00:00")
-    expect_identical(minus(nt, p, tz), expected)
+nt <- as.nanotime("2020-11-01 02:00:00 America/New_York")
+p <- as.nanoperiod("01:00:00")
+tz <- "America/New_York"
+## expected <- as.nanotime("2020-11-01 01:00:00 America/New_York")    # ambiguous
+expected <- as.nanotime("2020-11-01 06:00:00+00:00")
+expect_identical(minus(nt, p, tz), expected)
 
-    nt <- as.nanotime("2020-11-01 02:00:00 America/New_York")
-    p <- as.nanoperiod("01:00:00")
-    tz <- "America/New_York"
-    ## expected <- as.nanotime("2020-11-01 01:00:00 America/New_York")    # ambiguous
-    expected <- as.nanotime("2020-11-01 06:00:00+00:00")
-    expect_identical(minus(nt, p, tz), expected)
-    
-    
-    ## adding/subtracting a nanoperiod should realign if doing so does
-    ## not cross again a DST boundary:    
 
-    ## look at cases over the Spring boundary in America:
-    nt <- as.nanotime("2020-03-08 01:00:00 America/New_York")
-    p <- as.nanoperiod("02:00:01")
-    tz <- "America/New_York"
-    expected <- as.nanotime("2020-03-08 03:00:01 America/New_York")
-    expect_identical(plus(nt, p, tz), expected)
+## adding/subtracting a nanoperiod should realign if doing so does
+## not cross again a DST boundary:
 
-    nt <- as.nanotime("2020-03-08 03:00:00 America/New_York")
-    p <- as.nanoperiod("02:00:01")
-    tz <- "America/New_York"
-    expected <- as.nanotime("2020-03-08 00:59:59 America/New_York")
-    expect_identical(minus(nt, p, tz), expected)
+## look at cases over the Spring boundary in America:
+nt <- as.nanotime("2020-03-08 01:00:00 America/New_York")
+p <- as.nanoperiod("02:00:01")
+tz <- "America/New_York"
+expected <- as.nanotime("2020-03-08 03:00:01 America/New_York")
+expect_identical(plus(nt, p, tz), expected)
 
-    ## look at the cases over the Autumn boundary in America:
-    nt <- as.nanotime("2020-11-01 01:00:00 America/New_York")
-    p <- as.nanoperiod("02:00:01")
-    tz <- "America/New_York"
-    expected <- as.nanotime("2020-11-01 03:00:01 America/New_York")
-    expect_identical(plus(nt, p, tz), expected)
+nt <- as.nanotime("2020-03-08 03:00:00 America/New_York")
+p <- as.nanoperiod("02:00:01")
+tz <- "America/New_York"
+expected <- as.nanotime("2020-03-08 00:59:59 America/New_York")
+expect_identical(minus(nt, p, tz), expected)
 
-    nt <- as.nanotime("2020-11-01 03:00:00 America/New_York")
-    p <- as.nanoperiod("02:00:01")
-    tz <- "America/New_York"
-    expected <- as.nanotime("2020-11-01 00:59:59 America/New_York")
-    expect_identical(minus(nt, p, tz), expected)
-    
-    
-    ## plus/minus with 'nanoival':
+## look at the cases over the Autumn boundary in America:
+nt <- as.nanotime("2020-11-01 01:00:00 America/New_York")
+p <- as.nanoperiod("02:00:01")
+tz <- "America/New_York"
+expected <- as.nanotime("2020-11-01 03:00:01 America/New_York")
+expect_identical(plus(nt, p, tz), expected)
 
-    ##test_plus_nanoival_nanoperiod <- function() {
-    start <- nanotime("2018-01-01T05:00:00.000000000+00")
-    end <- nanotime("2018-01-01T23:00:00.000000000+00")
-    ni <- nanoival(start, end)
-    p  <- as.nanoperiod("4m")
-    tz <- "America/New_York"
-    expected <- as.nanoival("+2018-05-01T00:00:00.000000000-04:00 -> 2018-05-01T18:00:00.000000000-04:00-")
-    expect_identical(plus(ni, p, tz), expected)
+nt <- as.nanotime("2020-11-01 03:00:00 America/New_York")
+p <- as.nanoperiod("02:00:01")
+tz <- "America/New_York"
+expected <- as.nanotime("2020-11-01 00:59:59 America/New_York")
+expect_identical(minus(nt, p, tz), expected)
 
-    ##test_plus_nanoival_nanoperiod_pre_1970 <- function() {
-    start <- nanotime("1969-01-01T05:00:00.000000000+00")
-    end <- nanotime("1969-01-01T23:00:00.000000000+00")
-    ni <- nanoival(start, end)
-    p  <- as.nanoperiod("4m")
-    tz <- "America/New_York"
-    expected <- as.nanoival("+1969-05-01T00:00:00.000000000-04:00 -> 1969-05-01T18:00:00.000000000-04:00-")
-    expect_identical(plus(ni, p, tz), expected)
 
-    ##test_plus_nanoperiod_nanoival <- function() {
-    start <- nanotime("2018-01-01T05:00:00.000000000+00")
-    end <- nanotime("2018-01-01T23:00:00.000000000+00")
-    ni <- nanoival(start, end)
-    p  <- c(a=as.nanoperiod("4m"))
-    tz <- "America/New_York"
-    expected <- c(a=as.nanoival("+2018-05-01T00:00:00.000000000-04:00 -> 2018-05-01T18:00:00.000000000-04:00-"))
-    expect_identical(plus(p, ni, tz), expected)
+## plus/minus with 'nanoival':
 
-    ##test_minus_nanoival_nanoperiod <- function() {
-    start <- nanotime("2018-05-01T05:00:00.000000000-04")
-    end <- nanotime("2018-05-01T23:00:00.000000000-04")
-    ni <- c(a=nanoival(start, end))
-    p  <- as.nanoperiod("4m")
-    tz <- "America/New_York"
-    expected <- c(a=as.nanoival("+2018-01-01T05:00:00.000000000-05:00 -> 2018-01-01T23:00:00.000000000-05:00-"))
-    expect_identical(minus(ni, p, tz), expected)
+##test_plus_nanoival_nanoperiod <- function() {
+start <- nanotime("2018-01-01T05:00:00.000000000+00")
+end <- nanotime("2018-01-01T23:00:00.000000000+00")
+ni <- nanoival(start, end)
+p  <- as.nanoperiod("4m")
+tz <- "America/New_York"
+expected <- as.nanoival("+2018-05-01T00:00:00.000000000-04:00 -> 2018-05-01T18:00:00.000000000-04:00-")
+expect_identical(plus(ni, p, tz), expected)
 
-    ##test_minus_nanoperiod_nanoival <- function() {
-    start <- nanotime("2018-05-01T05:00:00.000000000-04")
-    end <- nanotime("2018-05-01T23:00:00.000000000-04")
-    ni <- nanoival(start, end)
-    p  <- as.nanoperiod("4m")
-    tz <- "America/New_York"
-    expect_error(minus(p, ni, tz), "operation not defined for 'nanoperiod' objects")
+##test_plus_nanoival_nanoperiod_pre_1970 <- function() {
+start <- nanotime("1969-01-01T05:00:00.000000000+00")
+end <- nanotime("1969-01-01T23:00:00.000000000+00")
+ni <- nanoival(start, end)
+p  <- as.nanoperiod("4m")
+tz <- "America/New_York"
+expected <- as.nanoival("+1969-05-01T00:00:00.000000000-04:00 -> 1969-05-01T18:00:00.000000000-04:00-")
+expect_identical(plus(ni, p, tz), expected)
 
-}
+##test_plus_nanoperiod_nanoival <- function() {
+start <- nanotime("2018-01-01T05:00:00.000000000+00")
+end <- nanotime("2018-01-01T23:00:00.000000000+00")
+ni <- nanoival(start, end)
+p  <- c(a=as.nanoperiod("4m"))
+tz <- "America/New_York"
+expected <- c(a=as.nanoival("+2018-05-01T00:00:00.000000000-04:00 -> 2018-05-01T18:00:00.000000000-04:00-"))
+expect_identical(plus(p, ni, tz), expected)
+
+##test_minus_nanoival_nanoperiod <- function() {
+start <- nanotime("2018-05-01T05:00:00.000000000-04")
+end <- nanotime("2018-05-01T23:00:00.000000000-04")
+ni <- c(a=nanoival(start, end))
+p  <- as.nanoperiod("4m")
+tz <- "America/New_York"
+expected <- c(a=as.nanoival("+2018-01-01T05:00:00.000000000-05:00 -> 2018-01-01T23:00:00.000000000-05:00-"))
+expect_identical(minus(ni, p, tz), expected)
+
+##test_minus_nanoperiod_nanoival <- function() {
+start <- nanotime("2018-05-01T05:00:00.000000000-04")
+end <- nanotime("2018-05-01T23:00:00.000000000-04")
+ni <- nanoival(start, end)
+p  <- as.nanoperiod("4m")
+tz <- "America/New_York"
+expect_error(minus(p, ni, tz), "operation not defined for 'nanoperiod' objects")
+
 
 ## NA stuff
 expect_true(is.na(as.nanoperiod(NA_integer_)))
@@ -728,8 +723,6 @@ expect_identical(all.equal(as.nanoperiod("1d"), NA_nanoperiod_), "'is.NA' value 
 ## test rounding functions:
 
 ## nano_ceiling:
-
-if (isSolaris) exit_file("skip remainder on Solaris")
 
 ## years:
 expect_identical(nano_ceiling(as.nanotime("2010-10-10 12:00:00 America/New_York"), as.nanoperiod("12m"), tz="America/New_York"),

--- a/inst/tinytest/test_nanotime.R
+++ b/inst/tinytest/test_nanotime.R
@@ -7,7 +7,6 @@ options(digits=7)                       # needed for error message of 0.3333333 
 
 expect_equal_numeric <- function(x,y,...) expect_equal(as.numeric(x), as.numeric(y), ...)
 
-isSolaris <- Sys.info()[["sysname"]] == "SunOS"
 isArm64 <- Sys.info()[["machine"]] == "arm64"
 
 ## nanotime constructors
@@ -21,97 +20,94 @@ expect_identical(as.nanotime(as.integer64(1)), new("nanotime", as.integer64(1)))
 ##test_nanotime_character_first_pass <- function() {
 ## we do a first pass parsing, which is faster than the parsing
 ## with the format string, and is also more forgiving
-if (!isSolaris) {
-    expect_identical(nanotime("2018-01-01T05:00:00.99 Europe/London"),             nanotime(as.integer64("1514782800990000000")))
-    expect_identical(nanotime("2018-01-01T05:00:00.999_999_999 America/New_York"), nanotime(as.integer64("1514800800999999999")))
-    expect_identical(nanotime("2018-01-01T05:00:00.999_999 America/New_York"),     nanotime(as.integer64("1514800800999999000")))
-    expect_identical(nanotime("2018-01-01T05:00:00.999 America/New_York"),         nanotime(as.integer64("1514800800999000000")))
-    expect_identical(nanotime("2018-01-01T05:00:00 America/New_York"),             nanotime(as.integer64("1514800800000000000")))
-    expect_identical(nanotime("2018-01-01 05:00:00 America/New_York"),             nanotime(as.integer64("1514800800000000000")))
-    expect_identical(nanotime("2018-01-01 05:00:00 America/New_York"),             nanotime(as.integer64("1514800800000000000")))
-    expect_identical(nanotime("2018-01-01 America/New_York"),                      nanotime(as.integer64("1514782800000000000")))
+expect_identical(nanotime("2018-01-01T05:00:00.99 Europe/London"),             nanotime(as.integer64("1514782800990000000")))
+expect_identical(nanotime("2018-01-01T05:00:00.999_999_999 America/New_York"), nanotime(as.integer64("1514800800999999999")))
+expect_identical(nanotime("2018-01-01T05:00:00.999_999 America/New_York"),     nanotime(as.integer64("1514800800999999000")))
+expect_identical(nanotime("2018-01-01T05:00:00.999 America/New_York"),         nanotime(as.integer64("1514800800999000000")))
+expect_identical(nanotime("2018-01-01T05:00:00 America/New_York"),             nanotime(as.integer64("1514800800000000000")))
+expect_identical(nanotime("2018-01-01 05:00:00 America/New_York"),             nanotime(as.integer64("1514800800000000000")))
+expect_identical(nanotime("2018-01-01 05:00:00 America/New_York"),             nanotime(as.integer64("1514800800000000000")))
+expect_identical(nanotime("2018-01-01 America/New_York"),                      nanotime(as.integer64("1514782800000000000")))
 
-    expect_identical(nanotime("2018-01-01T05:00:00.99+00:00"),                     nanotime(as.integer64("1514782800990000000")))
-    expect_identical(nanotime("2018-01-01T05:00:00.99-00:00"),                     nanotime(as.integer64("1514782800990000000")))
-    expect_identical(nanotime("2018-01-01T05:00:00.999_999_999+05:00"),            nanotime(as.integer64("1514764800999999999")))
-    expect_identical(nanotime("2018-01-01T05:00:00.999_999+05:00"),                nanotime(as.integer64("1514764800999999000")))
-    expect_identical(nanotime("2018-01-01T05:00:00.999+05:00"),                    nanotime(as.integer64("1514764800999000000")))
-    expect_identical(nanotime("2018-01-01T05:00:00+05:00"),                        nanotime(as.integer64("1514764800000000000")))
-    expect_identical(nanotime("2018-01-01 05:00:00+05:00"),                        nanotime(as.integer64("1514764800000000000")))
-    expect_identical(nanotime("2018-01-01 05:00:00+05:00"),                        nanotime(as.integer64("1514764800000000000")))
-    expect_identical(nanotime("2018-01-01   05:00:00+05:00"),                      nanotime(as.integer64("1514764800000000000")))
-    expect_identical(nanotime("2018-01-01+05:00"),                                 nanotime(as.integer64("1514746800000000000")))
+expect_identical(nanotime("2018-01-01T05:00:00.99+00:00"),                     nanotime(as.integer64("1514782800990000000")))
+expect_identical(nanotime("2018-01-01T05:00:00.99-00:00"),                     nanotime(as.integer64("1514782800990000000")))
+expect_identical(nanotime("2018-01-01T05:00:00.999_999_999+05:00"),            nanotime(as.integer64("1514764800999999999")))
+expect_identical(nanotime("2018-01-01T05:00:00.999_999+05:00"),                nanotime(as.integer64("1514764800999999000")))
+expect_identical(nanotime("2018-01-01T05:00:00.999+05:00"),                    nanotime(as.integer64("1514764800999000000")))
+expect_identical(nanotime("2018-01-01T05:00:00+05:00"),                        nanotime(as.integer64("1514764800000000000")))
+expect_identical(nanotime("2018-01-01 05:00:00+05:00"),                        nanotime(as.integer64("1514764800000000000")))
+expect_identical(nanotime("2018-01-01 05:00:00+05:00"),                        nanotime(as.integer64("1514764800000000000")))
+expect_identical(nanotime("2018-01-01   05:00:00+05:00"),                      nanotime(as.integer64("1514764800000000000")))
+expect_identical(nanotime("2018-01-01+05:00"),                                 nanotime(as.integer64("1514746800000000000")))
 
-    expect_identical(nanotime("2018/01/01T05:00:00.99 Europe/London"),             nanotime(as.integer64("1514782800990000000")))
-    expect_identical(nanotime("2018 01 01T05:00:00.99 Europe/London"),             nanotime(as.integer64("1514782800990000000")))   
+expect_identical(nanotime("2018/01/01T05:00:00.99 Europe/London"),             nanotime(as.integer64("1514782800990000000")))
+expect_identical(nanotime("2018 01 01T05:00:00.99 Europe/London"),             nanotime(as.integer64("1514782800990000000")))
 
-    ## test the alias 'as.nanotime':
-    expect_identical(as.nanotime("2018-01-01T05:00:00.99 Europe/London"),             nanotime(as.integer64("1514782800990000000")))
-    expect_identical(as.nanotime("2018-01-01T05:00:00.999_999_999 America/New_York"), nanotime(as.integer64("1514800800999999999")))
-    expect_identical(as.nanotime("2018-01-01T05:00:00.999_999 America/New_York"),     nanotime(as.integer64("1514800800999999000")))
-    expect_identical(as.nanotime("2018-01-01T05:00:00.999 America/New_York"),         nanotime(as.integer64("1514800800999000000")))
-    expect_identical(as.nanotime("2018-01-01T05:00:00 America/New_York"),             nanotime(as.integer64("1514800800000000000")))
-    expect_identical(as.nanotime("2018-01-01 05:00:00 America/New_York"),             nanotime(as.integer64("1514800800000000000")))
-    expect_identical(as.nanotime("2018-01-01 05:00:00 America/New_York"),             nanotime(as.integer64("1514800800000000000")))
-    expect_identical(as.nanotime("2018-01-01 America/New_York"),                      nanotime(as.integer64("1514782800000000000")))
+## test the alias 'as.nanotime':
+expect_identical(as.nanotime("2018-01-01T05:00:00.99 Europe/London"),             nanotime(as.integer64("1514782800990000000")))
+expect_identical(as.nanotime("2018-01-01T05:00:00.999_999_999 America/New_York"), nanotime(as.integer64("1514800800999999999")))
+expect_identical(as.nanotime("2018-01-01T05:00:00.999_999 America/New_York"),     nanotime(as.integer64("1514800800999999000")))
+expect_identical(as.nanotime("2018-01-01T05:00:00.999 America/New_York"),         nanotime(as.integer64("1514800800999000000")))
+expect_identical(as.nanotime("2018-01-01T05:00:00 America/New_York"),             nanotime(as.integer64("1514800800000000000")))
+expect_identical(as.nanotime("2018-01-01 05:00:00 America/New_York"),             nanotime(as.integer64("1514800800000000000")))
+expect_identical(as.nanotime("2018-01-01 05:00:00 America/New_York"),             nanotime(as.integer64("1514800800000000000")))
+expect_identical(as.nanotime("2018-01-01 America/New_York"),                      nanotime(as.integer64("1514782800000000000")))
 
-    expect_identical(as.nanotime("2018-01-01T05:00:00.99+00:00"),                     nanotime(as.integer64("1514782800990000000")))
-    expect_identical(as.nanotime("2018-01-01T05:00:00.99-00:00"),                     nanotime(as.integer64("1514782800990000000")))
-    expect_identical(as.nanotime("2018-01-01T05:00:00.999_999_999+05:00"),            nanotime(as.integer64("1514764800999999999")))
-    expect_identical(as.nanotime("2018-01-01T05:00:00.999_999+05:00"),                nanotime(as.integer64("1514764800999999000")))
-    expect_identical(as.nanotime("2018-01-01T05:00:00.999+05:00"),                    nanotime(as.integer64("1514764800999000000")))
-    expect_identical(as.nanotime("2018-01-01T05:00:00+05:00"),                        nanotime(as.integer64("1514764800000000000")))
-    expect_identical(as.nanotime("2018-01-01 05:00:00+05:00"),                        nanotime(as.integer64("1514764800000000000")))
-    expect_identical(as.nanotime("2018-01-01 05:00:00+05:00"),                        nanotime(as.integer64("1514764800000000000")))
-    expect_identical(as.nanotime("2018-01-01   05:00:00+05:00"),                      nanotime(as.integer64("1514764800000000000")))
-    expect_identical(as.nanotime("2018-01-01+05:00"),                                 nanotime(as.integer64("1514746800000000000")))
+expect_identical(as.nanotime("2018-01-01T05:00:00.99+00:00"),                     nanotime(as.integer64("1514782800990000000")))
+expect_identical(as.nanotime("2018-01-01T05:00:00.99-00:00"),                     nanotime(as.integer64("1514782800990000000")))
+expect_identical(as.nanotime("2018-01-01T05:00:00.999_999_999+05:00"),            nanotime(as.integer64("1514764800999999999")))
+expect_identical(as.nanotime("2018-01-01T05:00:00.999_999+05:00"),                nanotime(as.integer64("1514764800999999000")))
+expect_identical(as.nanotime("2018-01-01T05:00:00.999+05:00"),                    nanotime(as.integer64("1514764800999000000")))
+expect_identical(as.nanotime("2018-01-01T05:00:00+05:00"),                        nanotime(as.integer64("1514764800000000000")))
+expect_identical(as.nanotime("2018-01-01 05:00:00+05:00"),                        nanotime(as.integer64("1514764800000000000")))
+expect_identical(as.nanotime("2018-01-01 05:00:00+05:00"),                        nanotime(as.integer64("1514764800000000000")))
+expect_identical(as.nanotime("2018-01-01   05:00:00+05:00"),                      nanotime(as.integer64("1514764800000000000")))
+expect_identical(as.nanotime("2018-01-01+05:00"),                                 nanotime(as.integer64("1514746800000000000")))
 
-    expect_identical(as.nanotime("2018/01/01T05:00:00.99 Europe/London"),             nanotime(as.integer64("1514782800990000000")))
-    expect_identical(as.nanotime("2018 01 01T05:00:00.99 Europe/London"),             nanotime(as.integer64("1514782800990000000")))   
+expect_identical(as.nanotime("2018/01/01T05:00:00.99 Europe/London"),             nanotime(as.integer64("1514782800990000000")))
+expect_identical(as.nanotime("2018 01 01T05:00:00.99 Europe/London"),             nanotime(as.integer64("1514782800990000000")))
 
-    expect_identical(as.nanotime(NULL), nanotime())
-    expect_identical(as.nanotime(NULL), as.nanotime())
+expect_identical(as.nanotime(NULL), nanotime())
+expect_identical(as.nanotime(NULL), as.nanotime())
 
-    ##test_nanotime_character_first_pass_fail <- function() {
-    ## none of these should parse
-    expect_error(nanotime("2018-01-01T05:00:00.99 America/New_dYork"),  "Cannot retrieve timezone")
-    expect_error(nanotime("2018--01-01T05:00:00.99 America/New_York"),  "Parse error")
-    expect_error(nanotime("2018-01-01T05:00:00.99 America/New_York s"), "Parse error")
-    expect_error(nanotime("2018-01-01T05:00:s0.99 America/New_York"),   "Parse error")
-    expect_error(nanotime("2018-01-01T05:00:00.a99 America/New_York"), "Parse error")
-    expect_error(nanotime("2018-01-01T05:00:00.0000000000 America/New_York"), "Parse error")
-    expect_error(nanotime("201"), "Parse error")
-    expect_error(nanotime("2018-13-01T05:00:00.99 Europe/London"), "Parse error")
-    expect_error(nanotime("2018"), "Parse error")
-    expect_error(nanotime("2018-1"), "Parse error")
-    expect_error(nanotime("2018-01-32T05:00:00.99 Europe/London"), "Parse error")
-    expect_error(nanotime("2018-01-01T25:00:00.99 Europe/London"), "Parse error")
-    expect_error(nanotime("2018-01-01T05:61:00.99 Europe/London"), "Parse error")
-    expect_error(nanotime("2018-01-01T05:00:61.99 Europe/London"), "Parse error")
-    expect_error(nanotime("2018-01-01T05:00:00.99999999999 Europe/London"), "Parse error")
-    expect_error(nanotime("2018-01-01T05:00:00.99 Europe/London%"), "Parse error")
-    expect_error(nanotime("2018-01-01T05:00:00.99 %"), "Parse error")
+##test_nanotime_character_first_pass_fail <- function() {
+## none of these should parse
+expect_error(nanotime("2018-01-01T05:00:00.99 America/New_dYork"),  "Cannot retrieve timezone")
+expect_error(nanotime("2018--01-01T05:00:00.99 America/New_York"),  "Parse error")
+expect_error(nanotime("2018-01-01T05:00:00.99 America/New_York s"), "Parse error")
+expect_error(nanotime("2018-01-01T05:00:s0.99 America/New_York"),   "Parse error")
+expect_error(nanotime("2018-01-01T05:00:00.a99 America/New_York"), "Parse error")
+expect_error(nanotime("2018-01-01T05:00:00.0000000000 America/New_York"), "Parse error")
+expect_error(nanotime("201"), "Parse error")
+expect_error(nanotime("2018-13-01T05:00:00.99 Europe/London"), "Parse error")
+expect_error(nanotime("2018"), "Parse error")
+expect_error(nanotime("2018-1"), "Parse error")
+expect_error(nanotime("2018-01-32T05:00:00.99 Europe/London"), "Parse error")
+expect_error(nanotime("2018-01-01T25:00:00.99 Europe/London"), "Parse error")
+expect_error(nanotime("2018-01-01T05:61:00.99 Europe/London"), "Parse error")
+expect_error(nanotime("2018-01-01T05:00:61.99 Europe/London"), "Parse error")
+expect_error(nanotime("2018-01-01T05:00:00.99999999999 Europe/London"), "Parse error")
+expect_error(nanotime("2018-01-01T05:00:00.99 Europe/London%"), "Parse error")
+expect_error(nanotime("2018-01-01T05:00:00.99 %"), "Parse error")
 
-    expect_error(as.nanotime("2013-01-01 00:00:00 America/New_York", tz="Europe/London"),
-                 "timezone is specified twice: in the string and as an argument")
-}
+expect_error(as.nanotime("2013-01-01 00:00:00 America/New_York", tz="Europe/London"),
+             "timezone is specified twice: in the string and as an argument")
 
 ##test_nanotime_character_second_pass  <- function() {
 ## if the parsing above has failed, then we use a second parsing
 ## that is based on the format string that is provided
-if (!isSolaris) {
-    oldFormat <- getOption("nanotimeFormat")
-    oldTz <- getOption("nanotimeTz")
-    ## check that the format and time zone is picked up from the global options:
-    options(nanotimeFormat="%Y|%m|%d %H:%M")
-    options(nanotimeTz="America/New_York")
-    expect_identical(nanotime("1970|01|01 00:00"), nanotime(18000000000000))
-    ## check they are overridden by the parameters:
-    expect_identical(nanotime("1970|01|01 00:00:01", format="%Y|%m|%d %H:%M:%S", tz="Europe/Paris"),
-                     nanotime(-3599000000000))
-    options(nanotimeFormat=oldFormat)
-    options(nanotimeTz=oldTz)
-}
+oldFormat <- getOption("nanotimeFormat")
+oldTz <- getOption("nanotimeTz")
+## check that the format and time zone is picked up from the global options:
+options(nanotimeFormat="%Y|%m|%d %H:%M")
+options(nanotimeTz="America/New_York")
+expect_identical(nanotime("1970|01|01 00:00"), nanotime(18000000000000))
+## check they are overridden by the parameters:
+expect_identical(nanotime("1970|01|01 00:00:01", format="%Y|%m|%d %H:%M:%S", tz="Europe/Paris"),
+                 nanotime(-3599000000000))
+options(nanotimeFormat=oldFormat)
+options(nanotimeTz=oldTz)
+
 ##test_nanotime_character_second_pass_fail  <- function() {
 oldFormat <- getOption("nanotimeFormat")
 oldTz <- getOption("nanotimeTz")
@@ -126,11 +122,9 @@ options(nanotimeTz=oldTz)
 
 
 ##test_nanotime_matrix <- function() {
-if (!isSolaris) {
-    m <- matrix(c(10*24*3600+0:9, 987654321+0:9), 10, 2)
-    expect_identical(nanotime.matrix(m),
-                     nanotime("1970-01-11T00:00:00.987654321+00:00") + seq(0, 9e9, by=1e9) + 0:9)
-}
+m <- matrix(c(10*24*3600+0:9, 987654321+0:9), 10, 2)
+expect_identical(nanotime.matrix(m),
+                 nanotime("1970-01-11T00:00:00.987654321+00:00") + seq(0, 9e9, by=1e9) + 0:9)
 
 ##test_nanotime_POSIXct <- function() {
 p <- as.POSIXct("1970-01-01 00:00:00", tz="America/New_York", accurate=FALSE)
@@ -166,11 +160,9 @@ n <- nanotime(c(a=1, b=2))
 expect_identical(names(n), c("a","b"))
 
 ##test_nanotime_character_keep_names <- function() {
-if (!isSolaris) {
-    n <- nanotime(c(a="1970-01-01T00:00:00.000000001+00:00",
-                    b="1970-01-01T00:00:00.000000001+00:00"))
-    expect_identical(names(n), c("a","b"))
-}
+n <- nanotime(c(a="1970-01-01T00:00:00.000000001+00:00",
+                b="1970-01-01T00:00:00.000000001+00:00"))
+expect_identical(names(n), c("a","b"))
 
 ##test_nanotime_POSIXct_keep_names <- function() {
 p <- as.POSIXct("1970-01-01 00:00:00", tz="America/New_York")
@@ -207,63 +199,57 @@ options(nanotimeFormat=oldFormat)
 options(nanotimeTz=oldTz)
 
 ##test_format_tz <- function() {
-if (!isSolaris) {
-    oldFormat <- getOption("nanotimeFormat")
-    oldTz <- getOption("nanotimeTz")
-    options(nanotimeFormat=NULL)
+oldFormat <- getOption("nanotimeFormat")
+oldTz <- getOption("nanotimeTz")
+options(nanotimeFormat=NULL)
 
-    a_utc = "1970-01-01T00:00:00+00:00"
-    nt <- nanotime(a_utc)
-    a_ny <- "1969-12-31T19:00:00-05:00"
+a_utc = "1970-01-01T00:00:00+00:00"
+nt <- nanotime(a_utc)
+a_ny <- "1969-12-31T19:00:00-05:00"
 
-    options(nanotimeTz=NULL)
-    expect_identical(format(nt, tz="America/New_York"), a_ny)
+options(nanotimeTz=NULL)
+expect_identical(format(nt, tz="America/New_York"), a_ny)
 
-    options(nanotimeTz="UTC")
-    expect_identical(format(nt, tz="America/New_York"), a_ny)
+options(nanotimeTz="UTC")
+expect_identical(format(nt, tz="America/New_York"), a_ny)
 
-    attr(nt, "tzone") <- "UTC"
-    expect_identical(format(nt, tz="America/New_York"), a_ny)
-    expect_identical(format(nt, tz=""), a_utc)
+attr(nt, "tzone") <- "UTC"
+expect_identical(format(nt, tz="America/New_York"), a_ny)
+expect_identical(format(nt, tz=""), a_utc)
 
-    options(nanotimeFormat=oldFormat)
-    options(nanotimeTz=oldTz)
-}
+options(nanotimeFormat=oldFormat)
+options(nanotimeTz=oldTz)
 
 ##test_format_tzone <- function() {
-if (!isSolaris) {
-    oldFormat <- getOption("nanotimeFormat")
-    oldTz <- getOption("nanotimeTz")
-    options(nanotimeFormat=NULL)
+oldFormat <- getOption("nanotimeFormat")
+oldTz <- getOption("nanotimeTz")
+options(nanotimeFormat=NULL)
 
-    a <- nanotime("1970-01-01T00:00:00.001000000+00:00")
-    attr(a, "tzone") <- "America/New_York"
-    a_ny <- "1969-12-31T19:00:00.001-05:00"
+a <- nanotime("1970-01-01T00:00:00.001000000+00:00")
+attr(a, "tzone") <- "America/New_York"
+a_ny <- "1969-12-31T19:00:00.001-05:00"
 
-    expect_identical(format(a), a_ny)
+expect_identical(format(a), a_ny)
 
-    options(nanotimeTz="UTC")
-    expect_identical(format(a), a_ny)
+options(nanotimeTz="UTC")
+expect_identical(format(a), a_ny)
 
-    options(nanotimeFormat=oldFormat)
-    options(nanotimeTz=oldTz)
-}
+options(nanotimeFormat=oldFormat)
+options(nanotimeTz=oldTz)
 
 ##test_format_tz_from_options <- function() {
-if (!isSolaris) {
-    oldFormat <- getOption("nanotimeFormat")
-    oldTz <- getOption("nanotimeTz")
-    options(nanotimeFormat=NULL)
-    options(nanotimeTz="America/New_York")
+oldFormat <- getOption("nanotimeFormat")
+oldTz <- getOption("nanotimeTz")
+options(nanotimeFormat=NULL)
+options(nanotimeTz="America/New_York")
 
-    a <- nanotime("1970-01-01T00:00:00.000001000+00:00")
-    a_ny <- "1969-12-31T19:00:00.000001-05:00"
+a <- nanotime("1970-01-01T00:00:00.000001000+00:00")
+a_ny <- "1969-12-31T19:00:00.000001-05:00"
 
-    expect_identical(format(a), a_ny)
+expect_identical(format(a), a_ny)
 
-    options(nanotimeFormat=oldFormat)
-    options(nanotimeTz=oldTz)
-}
+options(nanotimeFormat=oldFormat)
+options(nanotimeTz=oldTz)
 
 ##test_format_fmt_default <- function() {
 oldFormat <- getOption("nanotimeFormat")
@@ -280,40 +266,36 @@ options(nanotimeFormat=oldFormat)
 options(nanotimeTz=oldTz)
 
 ##test_format_fmt_from_options <- function() {
-if (!isSolaris) {
-    oldFormat <- getOption("nanotimeFormat")
-    oldTz <- getOption("nanotimeTz")
-    options(nanotimeFormat="%Y/%m/%dT%H:%M:%E9S%Ez")
-    options(nanotimeTz="America/New_York")
+oldFormat <- getOption("nanotimeFormat")
+oldTz <- getOption("nanotimeTz")
+options(nanotimeFormat="%Y/%m/%dT%H:%M:%E9S%Ez")
+options(nanotimeTz="America/New_York")
 
-    a <- nanotime("1970/01/01T00:00:00.000000000+00:00")
-    a_ny <- "1969/12/31T19:00:00.000000000-05:00"
+a <- nanotime("1970/01/01T00:00:00.000000000+00:00")
+a_ny <- "1969/12/31T19:00:00.000000000-05:00"
 
-    expect_identical(format(a), a_ny)
+expect_identical(format(a), a_ny)
 
-    options(nanotimeFormat=oldFormat)
-    options(nanotimeTz=oldTz)
-}
+options(nanotimeFormat=oldFormat)
+options(nanotimeTz=oldTz)
 
 ##test_format_fmt_from_parameter <- function() {
-if (!isSolaris) {
-    oldFormat <- getOption("nanotimeFormat")
-    oldTz <- getOption("nanotimeTz")
-    options(nanotimeFormat="%Y/%m/%dT%H:%M:%E9S%Ez")
-    options(nanotimeTz="America/New_York")
+oldFormat <- getOption("nanotimeFormat")
+oldTz <- getOption("nanotimeTz")
+options(nanotimeFormat="%Y/%m/%dT%H:%M:%E9S%Ez")
+options(nanotimeTz="America/New_York")
 
-    a <- nanotime("1970-01-01 00:00:00.000000000+00:00", format="%Y-%m-%d %H:%M:%E9S%Ez")
+a <- nanotime("1970-01-01 00:00:00.000000000+00:00", format="%Y-%m-%d %H:%M:%E9S%Ez")
                                         # the result of format on a is taken from the global option:
-    a_ny <- "1969/12/31T19:00:00.000000000-05:00"
+a_ny <- "1969/12/31T19:00:00.000000000-05:00"
 
-    expect_identical(format(a), a_ny)
+expect_identical(format(a), a_ny)
 
-    options(nanotimeFormat=oldFormat)
-    options(nanotimeTz=oldTz)
-}
+options(nanotimeFormat=oldFormat)
+options(nanotimeTz=oldTz)
 
 ##test_format_na <- function() {
-if (FALSE && !isSolaris) {
+if (FALSE) {
     f <- format(nanotime(c(1, NA, 2, NaN)))
     exp <- c("1970-01-01T00:00:00.000000001+00:00",
              as.character(NA),
@@ -514,14 +496,12 @@ expect_true(is.na(NA_nanotime_))
 
 ## test square bracket (#44)
 ##test_square_bracket <- function() {
-if (!isSolaris) {
-    times <- c(nanotime('2011-12-05 08:30:00.000',format ="%Y-%m-%d %H:%M:%E9S",  tz ="GMT"),
-               nanotime('2011-12-05 08:30:00.100',format ="%Y-%m-%d %H:%M:%E9S",  tz ="GMT"),
-               nanotime('2011-12-05 08:30:00.825',format ="%Y-%m-%d %H:%M:%E9S",  tz ="GMT"))
-    expect_identical(times[1], times[[1]])
-    expect_identical(times[2], times[[2]])
-    expect_identical(times[3], times[[3]])
-}
+times <- c(nanotime('2011-12-05 08:30:00.000',format ="%Y-%m-%d %H:%M:%E9S",  tz ="GMT"),
+           nanotime('2011-12-05 08:30:00.100',format ="%Y-%m-%d %H:%M:%E9S",  tz ="GMT"),
+           nanotime('2011-12-05 08:30:00.825',format ="%Y-%m-%d %H:%M:%E9S",  tz ="GMT"))
+expect_identical(times[1], times[[1]])
+expect_identical(times[2], times[[2]])
+expect_identical(times[3], times[[3]])
 
 ## test compare
 expect_true(nanotime(1) == nanotime(1))
@@ -542,8 +522,6 @@ expect_true(nanotime(1) <= nanotime("1970-01-01T00:00:00.000000002+00"))
 expect_false(nanotime("1970-01-01T00:00:00.000000001+00") >= nanotime(2))
 expect_true(nanotime(1) < nanotime("1970-01-01T00:00:00.000000002+00"))
 expect_false(nanotime("1970-01-01T00:00:00.000000001+00") > nanotime(2))
-
-if (isSolaris) exit_file("skip remainder on Solaris")
 
 ## with POSIXt
 pt1 <- as.POSIXct(1, origin="1970-01-01", tz="UTC")
@@ -647,23 +625,21 @@ expect_error(seq(as.nanotime(1), by=as.nanoperiod("1d"), length.out=10), "'tz' i
 expect_error(seq(as.nanotime(1), to=as.nanotime(10), by=as.nanoperiod("1d")), "'tz' is a mandatory argument for sequences with a 'period' step")
 
 ## test date time component access
-if (!isSolaris) {
-    expect_identical(nano_wday(as.nanotime("2020-03-14 23:32:00-04:00"), "America/New_York"), 6L)
-    expect_identical(nano_wday(as.nanotime("2020-03-14 23:32:00 America/New_York"), "Europe/Paris"), 0L)
-    expect_identical(nano_mday(as.nanotime("2020-03-14 23:32:00-04:00"), "America/New_York"), 14L)
-    expect_identical(nano_mday(as.nanotime("2020-03-14 23:32:00 America/New_York"), "Europe/Paris"), 15L)
-    expect_identical(nano_month(as.nanotime("2020-12-31 23:32:00-04:00"), "America/New_York"), 12L)
-    expect_identical(nano_month(as.nanotime("2020-12-31 23:32:00 America/New_York"), "Europe/Paris"), 1L)
-    expect_identical(nano_year(as.nanotime("2020-12-31 23:32:00-04:00"), "America/New_York"), 2020L)
-    expect_identical(nano_year(as.nanotime("2020-12-31 23:32:00 America/New_York"), "Europe/Paris"), 2021L)
-    expect_identical(nano_year(nanotime(1:10), "America/New_York"), rep(1969L, 10))
-    expect_identical(nano_year(as.nanotime("1916-03-14 12:32:00-04:00"), "America/New_York"), 1916L)
+expect_identical(nano_wday(as.nanotime("2020-03-14 23:32:00-04:00"), "America/New_York"), 6L)
+expect_identical(nano_wday(as.nanotime("2020-03-14 23:32:00 America/New_York"), "Europe/Paris"), 0L)
+expect_identical(nano_mday(as.nanotime("2020-03-14 23:32:00-04:00"), "America/New_York"), 14L)
+expect_identical(nano_mday(as.nanotime("2020-03-14 23:32:00 America/New_York"), "Europe/Paris"), 15L)
+expect_identical(nano_month(as.nanotime("2020-12-31 23:32:00-04:00"), "America/New_York"), 12L)
+expect_identical(nano_month(as.nanotime("2020-12-31 23:32:00 America/New_York"), "Europe/Paris"), 1L)
+expect_identical(nano_year(as.nanotime("2020-12-31 23:32:00-04:00"), "America/New_York"), 2020L)
+expect_identical(nano_year(as.nanotime("2020-12-31 23:32:00 America/New_York"), "Europe/Paris"), 2021L)
+expect_identical(nano_year(nanotime(1:10), "America/New_York"), rep(1969L, 10))
+expect_identical(nano_year(as.nanotime("1916-03-14 12:32:00-04:00"), "America/New_York"), 1916L)
 
-    expect_error(nano_wday(as.nanotime("2020-03-14 23:32:00-04:00"), "America/Nu_York"), "Cannot retrieve timezone")
-    expect_error(nano_mday(as.nanotime("2020-03-14 23:32:00-04:00"), "America/Nu_York"), "Cannot retrieve timezone")
-    expect_error(nano_month(as.nanotime("2020-03-14 23:32:00-04:00"), "America/Nu_York"), "Cannot retrieve timezone")
-    expect_error(nano_year(as.nanotime("2020-03-14 23:32:00-04:00"), "America/Nu_York"), "Cannot retrieve timezone")
-}
+expect_error(nano_wday(as.nanotime("2020-03-14 23:32:00-04:00"), "America/Nu_York"), "Cannot retrieve timezone")
+expect_error(nano_mday(as.nanotime("2020-03-14 23:32:00-04:00"), "America/Nu_York"), "Cannot retrieve timezone")
+expect_error(nano_month(as.nanotime("2020-03-14 23:32:00-04:00"), "America/Nu_York"), "Cannot retrieve timezone")
+expect_error(nano_year(as.nanotime("2020-03-14 23:32:00-04:00"), "America/Nu_York"), "Cannot retrieve timezone")
 
 
 ## 0-length ops:

--- a/inst/tinytest/test_zoo.R
+++ b/inst/tinytest/test_zoo.R
@@ -1,10 +1,6 @@
 
 library(nanotime)
 
-isSolaris <- Sys.info()[["sysname"]] == "SunOS"
-
-if (isSolaris) exit_file("Skipping tests on Solaris.")
-
 #test_zoo <- function() {
 suppressMessages(library(zoo))
 set.seed(42)


### PR DESCRIPTION
A few of the test files were still checking if we tested under the dearly departed Solaris platform. These can now be retired and this PR does so.  

No new code. But whereever we indented as part of the 'are we under Solaris?' check, I undid the indent so visually the diff appears larger that it functionally is.