### PR TITLE
Accommodate r-devel changes in setdiff (fixes #132)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,12 @@
+2024-09-09  Dirk Eddelbuettel  <edd@debian.org>
+
+	* DESCRIPTION (Version, Date): Roll minor version and date
+
+	* R/nanoival.R (setdiff): Under R 4.5.0, call setdiff for integer64
+	* R/nanotime.R (setMethod): Under R 4.5.0, define unique method
+	* NAMESPACE: Conditionally export unique
+	* man/nanotime.Rd: Alias unique
+
 2024-08-31  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Authors@R): Added

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: nanotime
 Type: Package
 Title: Nanosecond-Resolution Time Support for R
-Version: 0.3.9.1
-Date: 2024-06-22
+Version: 0.3.9.2
+Date: 2024-09-09
 Authors@R: c(person("Dirk", "Eddelbuettel", role = c("aut", "cre"), email = "edd@debian.org",
                     comment = c(ORCID = "0000-0001-6419-907X")),
              person("Leonardo", "Silvestri", role = "aut"))
@@ -16,7 +16,7 @@ LinkingTo: Rcpp, RcppCCTZ, RcppDate
 License: GPL (>= 2)
 URL: https://github.com/eddelbuettel/nanotime, https://eddelbuettel.github.io/nanotime/, https://dirk.eddelbuettel.com/code/nanotime.html
 BugReports: https://github.com/eddelbuettel/nanotime/issues
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2
 Collate: 'nanotime.R' 'nanoival.R' 'nanoduration.R' 'nanoperiod.R' 'RcppExports.R'
 Encoding: UTF-8
 NeedsCompilation: yes

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -114,3 +114,5 @@ exportMethods(nano_floor)
 
 S3method("%in%", nanotime)
 exportMethods("%in%")
+
+if (getRversion() > "4.5.0") exportMethods(unique)

--- a/R/nanoival.R
+++ b/R/nanoival.R
@@ -818,7 +818,7 @@ setMethod("union",
 setMethod("setdiff",
           c("nanotime", "nanotime"),
           function(x, y) {
-              res <- callNextMethod()
+              res <- if (getRversion() >= "4.5.0") setdiff(as.integer64(x), as.integer64(y)) else callNextMethod()
               oldClass(res) <- "integer64"
               new("nanotime", res)
           })

--- a/R/nanotime.R
+++ b/R/nanotime.R
@@ -1048,3 +1048,14 @@ setMethod("rep", c(x = "nanotime"), function(x, ...) {
 as.character.nanotime <- function(x, ...) {
     format(x, ...)
 }
+
+if (getRversion() > "4.5.0")  {
+##' @rdname nanotime
+setMethod("unique",
+          "nanotime",
+          function(x) {
+              res <- callNextMethod()
+              oldClass(res) <- "integer64"
+              new("nanotime", res)
+          })
+}

--- a/man/nanotime.Rd
+++ b/man/nanotime.Rd
@@ -16,6 +16,7 @@
 \alias{as.nanotime,Date-method}
 \alias{print,nanotime-method}
 \alias{show,nanotime-method}
+\alias{unique,nanotime-method}
 \alias{format.nanotime}
 \alias{index2char.nanotime}
 \alias{as.POSIXct.nanotime}


### PR DESCRIPTION
This is the best I could come up to permit `nanotime` to check under both r-release and r-devel. It still seems imperfect given the explicit callout -- but as we are under a time limit by CRAN this may have to do.  @kurthornik if you have any more advice let us know.