### PR TITLE
Fix missing-braces issue for Rcomplex

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2024-10-30  Michael Chirico  <chiricom@google.com>
+
+    * src/period.cpp: Create `Rcomplex` objects in a more robust
+	  way that appeases `Wmissing-braces` compiler warnings on `clang`.
+
 2024-09-16  Dirk Eddelbuettel  <edd@debian.org>
 
  	* DESCRIPTION (Version, Date): Release 0.3.10

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,7 @@
 2024-10-30  Michael Chirico  <chiricom@google.com>
 
-    * src/period.cpp: Create `Rcomplex` objects in a more robust
-	  way that appeases `Wmissing-braces` compiler warnings on `clang`.
+	* src/period.cpp: Create `Rcomplex` objects in a more robust
+	way that appeases `Wmissing-braces` compiler warnings on `clang`.
 
 2024-09-16  Dirk Eddelbuettel  <edd@debian.org>
 

--- a/src/period.cpp
+++ b/src/period.cpp
@@ -11,11 +11,13 @@
 // See comment in <R_Ext/Complex.h> in R>=4.3.0. As of 2024-10-30
 //   clang trunk with -Wmissing-braces requires the double-braced
 //   approach for creating Rcomplex objects.
-#if R_VERSION >= R_Version(4, 3, 0)
-#define RCOMPLEX(RE, IM) Rcomplex{{RE, IM}}
+Rcomplex makeComplex(double *re, double *im) {
+#if R_VERSION >= R_Version(4, 4, 0)
+  return Rcomplex{{*re, *im}};
 #else
-#define RCOMPLEX(RE, IM) Rcomplex{RE, IM}
+  return Rcomplex{*re, *im};
 #endif
+}
 
 using namespace nanotime;
 
@@ -193,7 +195,7 @@ Rcpp::ComplexVector period_from_string_impl(Rcpp::CharacterVector str) {
   for (R_xlen_t i=0; i<str.size(); ++i) {
     period prd(Rcpp::as<std::string>(str[i]));
     period_union pu = { { prd.getMonths(), prd.getDays(), prd.getDuration().count() } };
-    res[i] = RCOMPLEX(pu.dbl2.d1, pu.dbl2.d2 );
+    res[i] = makeComplex(pu.dbl2.d1, pu.dbl2.d2 );
   }
   if (str.hasAttribute("names")) {
     res.names() = str.names();
@@ -214,7 +216,7 @@ Rcpp::ComplexVector period_from_parts_impl(Rcpp::IntegerVector months_v, Rcpp::I
     for (R_xlen_t i=0; i<res.size(); ++i) {
       const auto dur_i = *reinterpret_cast<const int64_t*>(&dur[i]);
       period_union pu = { { months[i], days[i], dur_i } };
-      res[i] = RCOMPLEX(pu.dbl2.d1, pu.dbl2.d2 );
+      res[i] = makeComplex(pu.dbl2.d1, pu.dbl2.d2 );
     }
   }
   return assignS4("nanoperiod", res);
@@ -257,11 +259,11 @@ Rcpp::ComplexVector period_from_integer64_impl(Rcpp::NumericVector i64) {
     auto elt = *reinterpret_cast<std::int64_t*>(&i64[i]);
     if (elt == NA_INTEGER64) {
       period_union pu = { { NA_INTEGER, NA_INTEGER, NA_INTEGER64 } };
-      res[i] = RCOMPLEX(pu.dbl2.d1, pu.dbl2.d2 );
+      res[i] = makeComplex(pu.dbl2.d1, pu.dbl2.d2 );
     }
     else {
       period_union pu = { { 0, 0, elt } };
-      res[i] = RCOMPLEX(pu.dbl2.d1, pu.dbl2.d2 );
+      res[i] = makeComplex(pu.dbl2.d1, pu.dbl2.d2 );
     }
   }
   if (i64.hasAttribute("names")) {
@@ -277,11 +279,11 @@ Rcpp::ComplexVector period_from_integer_impl(Rcpp::IntegerVector iint) {
   for (R_xlen_t i=0; i<iint.size(); ++i) {
     if (iint[i] == NA_INTEGER) {
       period_union pu = { { NA_INTEGER, NA_INTEGER, NA_INTEGER64 } };
-      res[i] = RCOMPLEX(pu.dbl2.d1, pu.dbl2.d2 );
+      res[i] = makeComplex(pu.dbl2.d1, pu.dbl2.d2 );
     }
     else {
       period_union pu = { { 0, 0, static_cast<std::int64_t>(iint[i]) } };
-      res[i] = RCOMPLEX(pu.dbl2.d1, pu.dbl2.d2 );
+      res[i] = makeComplex(pu.dbl2.d1, pu.dbl2.d2 );
     }
   }
   if (iint.hasAttribute("names")) {
@@ -297,11 +299,11 @@ Rcpp::ComplexVector period_from_double_impl(Rcpp::NumericVector dbl) {
   for (R_xlen_t i=0; i<dbl.size(); ++i) {
     if (ISNA(dbl[i])) {
       period_union pu = { { NA_INTEGER, NA_INTEGER, NA_INTEGER64 } };
-      res[i] = RCOMPLEX(pu.dbl2.d1, pu.dbl2.d2 );
+      res[i] = makeComplex(pu.dbl2.d1, pu.dbl2.d2 );
     }
     else {
       period_union pu = { { 0, 0, static_cast<std::int64_t>(dbl[i]) } };
-      res[i] = RCOMPLEX(pu.dbl2.d1, pu.dbl2.d2 );
+      res[i] = makeComplex(pu.dbl2.d1, pu.dbl2.d2 );
     }
   }
   if (dbl.hasAttribute("names")) {

--- a/src/period.cpp
+++ b/src/period.cpp
@@ -11,10 +11,10 @@
 // See comment in <R_Ext/Complex.h> in R>=4.3.0 and #134. Old
 //   approach to do `Rcomplex{ re, im }` now gives compiler issue
 //   on some compilers, R versions.
-inline Rcomplex makeComplex(double *re, double *im) {
+inline Rcomplex makeComplex(double re, double im) {
   Rcomplex ret;
-  ret.r = *re;
-  ret.i = *im;
+  ret.r = re;
+  ret.i = im;
   return ret;
 }
 

--- a/src/period.cpp
+++ b/src/period.cpp
@@ -8,6 +8,14 @@
 #include "nanotime/pseudovector.hpp"
 #include "nanotime/utilities.hpp"
 
+// See comment in <R_Ext/Complex.h> in R>=4.3.0. As of 2024-10-30
+//   clang trunk with -Wmissing-braces requires the double-braced
+//   approach for creating Rcomplex objects.
+#if R_VERSION >= R_Version(4, 3, 0)
+#define RCOMPLEX(RE, IM) Rcomplex{{RE, IM}}
+#else
+#define RCOMPLEX(RE, IM) Rcomplex{RE, IM}
+#endif
 
 using namespace nanotime;
 
@@ -185,7 +193,7 @@ Rcpp::ComplexVector period_from_string_impl(Rcpp::CharacterVector str) {
   for (R_xlen_t i=0; i<str.size(); ++i) {
     period prd(Rcpp::as<std::string>(str[i]));
     period_union pu = { { prd.getMonths(), prd.getDays(), prd.getDuration().count() } };
-    res[i] = Rcomplex{pu.dbl2.d1, pu.dbl2.d2 };
+    res[i] = RCOMPLEX(pu.dbl2.d1, pu.dbl2.d2 );
   }
   if (str.hasAttribute("names")) {
     res.names() = str.names();
@@ -206,7 +214,7 @@ Rcpp::ComplexVector period_from_parts_impl(Rcpp::IntegerVector months_v, Rcpp::I
     for (R_xlen_t i=0; i<res.size(); ++i) {
       const auto dur_i = *reinterpret_cast<const int64_t*>(&dur[i]);
       period_union pu = { { months[i], days[i], dur_i } };
-      res[i] = Rcomplex{pu.dbl2.d1, pu.dbl2.d2 };
+      res[i] = RCOMPLEX(pu.dbl2.d1, pu.dbl2.d2 );
     }
   }
   return assignS4("nanoperiod", res);
@@ -249,11 +257,11 @@ Rcpp::ComplexVector period_from_integer64_impl(Rcpp::NumericVector i64) {
     auto elt = *reinterpret_cast<std::int64_t*>(&i64[i]);
     if (elt == NA_INTEGER64) {
       period_union pu = { { NA_INTEGER, NA_INTEGER, NA_INTEGER64 } };
-      res[i] = Rcomplex{pu.dbl2.d1, pu.dbl2.d2 };
+      res[i] = RCOMPLEX(pu.dbl2.d1, pu.dbl2.d2 );
     }
     else {
       period_union pu = { { 0, 0, elt } };
-      res[i] = Rcomplex{pu.dbl2.d1, pu.dbl2.d2 };
+      res[i] = RCOMPLEX(pu.dbl2.d1, pu.dbl2.d2 );
     }
   }
   if (i64.hasAttribute("names")) {
@@ -269,11 +277,11 @@ Rcpp::ComplexVector period_from_integer_impl(Rcpp::IntegerVector iint) {
   for (R_xlen_t i=0; i<iint.size(); ++i) {
     if (iint[i] == NA_INTEGER) {
       period_union pu = { { NA_INTEGER, NA_INTEGER, NA_INTEGER64 } };
-      res[i] = Rcomplex{pu.dbl2.d1, pu.dbl2.d2 };
+      res[i] = RCOMPLEX(pu.dbl2.d1, pu.dbl2.d2 );
     }
     else {
       period_union pu = { { 0, 0, static_cast<std::int64_t>(iint[i]) } };
-      res[i] = Rcomplex{pu.dbl2.d1, pu.dbl2.d2 };
+      res[i] = RCOMPLEX(pu.dbl2.d1, pu.dbl2.d2 );
     }
   }
   if (iint.hasAttribute("names")) {
@@ -289,11 +297,11 @@ Rcpp::ComplexVector period_from_double_impl(Rcpp::NumericVector dbl) {
   for (R_xlen_t i=0; i<dbl.size(); ++i) {
     if (ISNA(dbl[i])) {
       period_union pu = { { NA_INTEGER, NA_INTEGER, NA_INTEGER64 } };
-      res[i] = Rcomplex{pu.dbl2.d1, pu.dbl2.d2 };
+      res[i] = RCOMPLEX(pu.dbl2.d1, pu.dbl2.d2 );
     }
     else {
       period_union pu = { { 0, 0, static_cast<std::int64_t>(dbl[i]) } };
-      res[i] = Rcomplex{pu.dbl2.d1, pu.dbl2.d2 };
+      res[i] = RCOMPLEX(pu.dbl2.d1, pu.dbl2.d2 );
     }
   }
   if (dbl.hasAttribute("names")) {

--- a/src/period.cpp
+++ b/src/period.cpp
@@ -8,15 +8,14 @@
 #include "nanotime/pseudovector.hpp"
 #include "nanotime/utilities.hpp"
 
-// See comment in <R_Ext/Complex.h> in R>=4.3.0. As of 2024-10-30
-//   clang trunk with -Wmissing-braces requires the double-braced
-//   approach for creating Rcomplex objects.
+// See comment in <R_Ext/Complex.h> in R>=4.3.0 and #134. Old
+//   approach to do `Rcomplex{ re, im }` now gives compiler issue
+//   on some compilers, R versions.
 inline Rcomplex makeComplex(double *re, double *im) {
-#if R_VERSION >= R_Version(4, 3, 0) && !defined(R_LEGACY_RCOMPLEX)
-  return Rcomplex{{*re, *im}};
-#else
-  return Rcomplex{*re, *im};
-#endif
+  Rcomplex ret;
+  ret.r = *re;
+  ret.i = *im;
+  return ret;
 }
 
 using namespace nanotime;

--- a/src/period.cpp
+++ b/src/period.cpp
@@ -8,9 +8,11 @@
 #include "nanotime/pseudovector.hpp"
 #include "nanotime/utilities.hpp"
 
-// See comment in <R_Ext/Complex.h> in R>=4.3.0 and #134. Old
-//   approach to do `Rcomplex{ re, im }` now gives compiler issue
-//   on some compilers, R versions.
+// From R>=4.3.0 the typedef of Rcomplex changed. Some modern strict
+//   compilers (e.g. 2024 clang -Wmissing-braces) get tripped up by
+//   'Rcomplex{re, im}' vs. 'Rcomplex{{re, im}}', the latter being technically
+//   more correct for the new typedef, though for many compilers this will
+//   "just work". See #134 and the comments in R_Ext/Complex.h.
 inline Rcomplex makeComplex(double re, double im) {
   Rcomplex ret;
   ret.r = re;

--- a/src/period.cpp
+++ b/src/period.cpp
@@ -12,7 +12,7 @@
 //   clang trunk with -Wmissing-braces requires the double-braced
 //   approach for creating Rcomplex objects.
 Rcomplex makeComplex(double *re, double *im) {
-#if R_VERSION >= R_Version(4, 4, 0)
+#if R_VERSION >= R_Version(4, 3, 0)
   return Rcomplex{{*re, *im}};
 #else
   return Rcomplex{*re, *im};

--- a/src/period.cpp
+++ b/src/period.cpp
@@ -11,8 +11,8 @@
 // See comment in <R_Ext/Complex.h> in R>=4.3.0. As of 2024-10-30
 //   clang trunk with -Wmissing-braces requires the double-braced
 //   approach for creating Rcomplex objects.
-Rcomplex makeComplex(double *re, double *im) {
-#if R_VERSION >= R_Version(4, 3, 0)
+inline Rcomplex makeComplex(double *re, double *im) {
+#if R_VERSION >= R_Version(4, 3, 0) && !defined(R_LEGACY_RCOMPLEX)
   return Rcomplex{{*re, *im}};
 #else
   return Rcomplex{*re, *im};


### PR DESCRIPTION
Closes #134. This approach avoids the need for old-vs-new preprocessor branching.