### PR TITLE
More careful treatment of NA values prior to CCTZ call

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2025-01-07  Dirk Eddelbuettel  <edd@debian.org>
+
+	* R/nanotime.R (format.nanotime): Index and override NA values prior
+	to CCTZ call, flag after call avoiding a UBSAN warning in client code
+
 2024-10-31  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Roll minor version and date

--- a/R/nanotime.R
+++ b/R/nanotime.R
@@ -296,8 +296,13 @@ format.nanotime <- function(x, format="", tz="", ...)
             }
         }
 
+        isna <- is.na(x)
+        if (any(isna)) {
+            secs[isna] <- 0
+            nanos[isna] <- 0
+        }
         res <- RcppCCTZ::formatDouble(as.double(secs), as.double(nanos), fmt=format, tgttzstr=tz)
-        res[is.na(x)] <- as.character(NA)
+        res[isna] <- as.character(NA)
         n <- names(x)
         if (!is.null(n)) {
             names(res) <- n


### PR DESCRIPTION
As reported by @trevorld and discussed quite extensively in [issue 45 of the RcppCCTZ repo](https://github.com/eddelbuettel/rcppcctz/issues/45), CRAN found an UBSAN warning in his package (that uses our pair of packages.

This PR modifies the behavior in the formatting helper (seen the in callstack in that report) slightly in that it identifies possible NA values and sets them to non-NA _before calling CCTZ_ and then flags the corresponding results as NA.  This allows use to continue to use 'non-standard' (in the IEEE sense) NA flags in characters (and ints and ... as R does) without tickling CCTZ.  We may want to look into dealing with it in RcppCCTZ in some places too, and there may be others here.