### PR TITLE
Refine version comparison

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,7 @@
 2025-03-26  Dirk Eddelbuettel  <edd@debian.org>
 
+	* DESCRIPTION (Suggests): Add ggplot2 now that demo/ is scanned
+
 	* R/nanotime.R (as.character.nanotime): Refine a version comparison
 
 2025-02-10  Dirk Eddelbuettel  <edd@debian.org>

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2025-03-26  Dirk Eddelbuettel  <edd@debian.org>
+
+	* R/nanotime.R (as.character.nanotime): Refine a version comparison
+
 2025-02-10  Dirk Eddelbuettel  <edd@debian.org>
 
 	* .github/workflows/ci.yaml (jobs): Use r-ci action with bootstrap

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: nanotime
 Type: Package
 Title: Nanosecond-Resolution Time Support for R
-Version: 0.3.11
-Date: 2025-01-10
+Version: 0.3.11.1
+Date: 2025-03-26
 Authors@R: c(person("Dirk", "Eddelbuettel", role = c("aut", "cre"), email = "edd@debian.org",
                     comment = c(ORCID = "0000-0001-6419-907X")),
              person("Leonardo", "Silvestri", role = "aut"))
@@ -11,7 +11,7 @@ Description: Full 64-bit resolution date and time functionality with
  the standard 'POSIXct' type. Three additional classes offer interval,
  period and duration functionality for nanosecond-resolution timestamps.
 Imports: methods, bit64, RcppCCTZ (>= 0.2.9), zoo
-Suggests: tinytest, data.table, xts
+Suggests: tinytest, data.table, xts, ggplot2
 LinkingTo: Rcpp, RcppCCTZ, RcppDate
 License: GPL (>= 2)
 URL: https://github.com/eddelbuettel/nanotime, https://eddelbuettel.github.io/nanotime/, https://dirk.eddelbuettel.com/code/nanotime.html

--- a/R/nanotime.R
+++ b/R/nanotime.R
@@ -1054,7 +1054,7 @@ as.character.nanotime <- function(x, ...) {
     format(x, ...)
 }
 
-if (getRversion() > "4.5.0")  {
+if (getRversion() >= "4.5.0")  {
 ##' @rdname nanotime
 setMethod("unique",
           "nanotime",


### PR DESCRIPTION
This is something I noticed when we examined the (as it turns out: non-)issue regarding S4.  We were comparing 'greater than' R 4.5.0 aka r-devel (for another week or two before it become the release), I think we want 'greater or equal'.  @lsilvest do you concur that this should be `>=` ?  This comes from what we added in September concerning `unique` and its dispatch.

Also adds ggplot2 to Suggests as we now must because demo/ is looked at.