### PR TITLE
Replace Rf_error with Rcpp::stop which unwinds exceptions better

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2026-02-27  Dirk Eddelbuettel  <edd@debian.org>
+
+	* inst/include/nanotime/globals.hpp: Updated to not require Rf_error
+	as Rcpp unwinding of exceptions is preferred
+
 2026-01-04  Dirk Eddelbuettel  <edd@debian.org>
 
 	* .github/workflows/ci.yaml: Switch to actions/checkout@v6

--- a/inst/include/nanotime/globals.hpp
+++ b/inst/include/nanotime/globals.hpp
@@ -3,13 +3,11 @@
 
 #include <chrono>
 #include <cctype>
-#include "date.h"
-#include "cctz/civil_time.h"
-#include "cctz/time_zone.h"
-
+#include "date.h"               // from Date via RcppDate
+#include "cctz/civil_time.h"    // from CCTZ via RcppCCTZ
+#include "cctz/time_zone.h"     // from CCTZ via RcppCCTZ
 
 namespace nanotime {
-
 
   using duration = std::chrono::nanoseconds;
   using dtime = std::chrono::time_point<std::chrono::system_clock, duration>;
@@ -64,7 +62,7 @@ namespace nanotime {
       return res;
     }
     else {
-      throw std::range_error("cannot parse datetime element");
+      Rcpp::stop("nanotime: cannot parse datetime element");
     }
   }
 
@@ -85,7 +83,7 @@ namespace nanotime {
       return std::string(s, sp-s);
     } 
     else {
-      throw std::range_error("cannot parse datetime timezone"); // # nocov
+      Rcpp::stop("nanotime: cannot parse datetime timezone"); // # nocov
     }
   }
 
@@ -116,83 +114,74 @@ namespace nanotime {
   
   inline tmdet readDtime(const char*& sp, const char* const se) 
   {
-    try {
-      const unsigned y = readInt(sp, se, 4, 4);
-      if (*sp == ' ' || *sp == '-' || *sp == '/') ++sp;
-      const unsigned m = readInt(sp, se, 2, 2);
-      if (*sp == ' ' || *sp == '-' || *sp == '/') ++sp;
-      const unsigned d = readInt(sp, se, 2, 2);
+    const unsigned y = readInt(sp, se, 4, 4);
+    if (*sp == ' ' || *sp == '-' || *sp == '/') ++sp;
+    const unsigned m = readInt(sp, se, 2, 2);
+    if (*sp == ' ' || *sp == '-' || *sp == '/') ++sp;
+    const unsigned d = readInt(sp, se, 2, 2);
 
-      skipWhitespace(sp, se);
-      if (sp < se && *sp == 'T') ++sp;
+    skipWhitespace(sp, se);
+    if (sp < se && *sp == 'T') ++sp;
 
-      unsigned h, mn, s;
-      if (isdigit(*sp) || *(sp-1) == 'T') {       // the time is optional
-        h = readInt(sp, se, 2, 2);
-        if (*sp == ':') ++sp;
-        mn = readInt(sp, se, 2, 2);
-        if (*sp == ':') ++sp;
-        s = readInt(sp, se, 2, 2);
-      } else {
-        h = mn = s = 0;
-      }
-
-      // optional fractional part
-      std::int64_t mul = 100000000;
-      std::int64_t ns = 0;
-      if (*sp == '.') {
-        ++sp;
-        unsigned i = 0;
-        while (sp < se && mul >= 1) {
-          if ((i == 3 || i == 6) && *sp == '_') { ++sp; continue; }
-          ++i;
-          if (!isdigit(*sp)) break;
-          ns += (*sp - '0') * mul;
-          mul /= 10;
-          ++sp;
-        }
-      }
-
-      skipWhitespace(sp, se);
-      
-      // not as much as we could test, but good enough without too much of
-      // a performance hit:
-      if (m < 1 || m > 12) throw std::range_error("month must be >= 1 and <= 12");
-      if (d < 1 || d > 31) throw std::range_error("day must be >= 1 and <= 31");
-      if (h > 23) throw std::range_error("hour must be < 24");
-      if (mn > 59) throw std::range_error("minute must be < 60");
-      if (s > 59) throw std::range_error("second must be < 60"); // debatable
-
-      // optional offset
-      std::string tzstr_str;    // need to persist this copy!
-      std::int64_t offset = 0;
-      if (*sp == '+' || *sp == '-') {
-        int64_t sign = *sp == '-' ? -1 : 1;
-        int64_t h_offset = readInt(++sp, se, 2, 2);
-        if (*sp != ':' && *sp != ' ') {
-          throw std::range_error("Error parsing offset");
-        }
-	int64_t m_offset = readInt(++sp, se, 2, 2);
-        offset = sign * h_offset * 3600 + m_offset * 60;
-        tzstr_str = "UTC";
-      } else if (isalpha(*sp)) {
-        // or timezone       
-        tzstr_str = readString(sp, se);
-      }
-      skipWhitespace(sp, se);
-
-      if (tzstr_str == "Z") {   // consider "Z" a shorhand for "UTC"
-        tzstr_str = "UTC";	// #nocov
-      }
-      return tmdet{y, m, d, h, mn, s, ns, tzstr_str, offset};
-      
-    } catch(std::exception &ex) {	
-      forward_exception_to_r(ex);
-    } catch(...) { 
-      ::Rf_error("c++ exception (unknown reason)"); 
+    unsigned h, mn, s;
+    if (isdigit(*sp) || *(sp-1) == 'T') {       // the time is optional
+      h = readInt(sp, se, 2, 2);
+      if (*sp == ':') ++sp;
+      mn = readInt(sp, se, 2, 2);
+      if (*sp == ':') ++sp;
+      s = readInt(sp, se, 2, 2);
+    } else {
+      h = mn = s = 0;
     }
-    // not reached:
-    return tmdet{0, 0, 0, 0, 0, 0, 0, "", 0};;
+
+    // optional fractional part
+    std::int64_t mul = 100000000;
+    std::int64_t ns = 0;
+    if (*sp == '.') {
+      ++sp;
+      unsigned i = 0;
+      while (sp < se && mul >= 1) {
+        if ((i == 3 || i == 6) && *sp == '_') { ++sp; continue; }
+        ++i;
+        if (!isdigit(*sp)) break;
+        ns += (*sp - '0') * mul;
+        mul /= 10;
+        ++sp;
+      }
+    }
+
+    skipWhitespace(sp, se);
+
+    // not as much as we could test, but good enough without too much of
+    // a performance hit:
+    if (m < 1 || m > 12) Rcpp::stop("nanotime: month must be >= 1 and <= 12");
+    if (d < 1 || d > 31) Rcpp::stop("nanotime: day must be >= 1 and <= 31");
+    if (h > 23) Rcpp::stop("nanotime: hour must be < 24");
+    if (mn > 59) Rcpp::stop("nanotime: minute must be < 60");
+    if (s > 59) Rcpp::stop("nanotime: second must be < 60"); // debatable
+
+    // optional offset
+    std::string tzstr_str;    // need to persist this copy!
+    std::int64_t offset = 0;
+    if (*sp == '+' || *sp == '-') {
+      int64_t sign = *sp == '-' ? -1 : 1;
+      int64_t h_offset = readInt(++sp, se, 2, 2);
+      if (*sp != ':' && *sp != ' ') {
+        Rcpp::stop("nanotime: Error parsing offset");
+      }
+      int64_t m_offset = readInt(++sp, se, 2, 2);
+      offset = sign * h_offset * 3600 + m_offset * 60;
+      tzstr_str = "UTC";
+    } else if (isalpha(*sp)) {
+      // or timezone
+      tzstr_str = readString(sp, se);
+    }
+    skipWhitespace(sp, se);
+
+    if (tzstr_str == "Z") {   // consider "Z" a shorhand for "UTC"
+      tzstr_str = "UTC";	// #nocov
+    }
+    return tmdet{y, m, d, h, mn, s, ns, tzstr_str, offset};
   }
 
   template<int T, class TT, class I, typename getNA>


### PR DESCRIPTION
Hi Leo,

This very small PR updates to a desiderate for Rcpp described in https://github.com/RcppCore/Rcpp/issues/1247 where use of `Rf_error()` is requested to be faced out.  'By now' we can do better directly inside of Rcpp and unwind exceptions better avoiding possibly corner cases.

Here, it means replacing a handful of `std::throw()` with `Rcpp::stop` and simply removing one `try ... catch` layer as it is covered inside Rcpp.

I don't expect any issues.  This code of yours had held up really well.  The PR below hides is a little, but there is basically just one big body moving two chars left as the outer `try { ... } catch { ... }` is gone, plus the handful of substitutions.

/cc @enchufa2 who is tirelessly driving this from the Rcpp side