### PR TITLE
Use NA_integer64_ directly in some tests

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2026-03-17  Michael Chirico  <chiricom@google.com>
+
+    * inst/tinytest/test_nanoduration.R Refactor tests using
+	  `as.integer64("-9223372036854775808")` to denote `NA_integer64_`, using
+	  that constant directly instead.
+
 2026-03-08  Dirk Eddelbuettel  <edd@debian.org>
 
  	* DESCRIPTION (Version, Date): Release 0.3.13

--- a/inst/tinytest/test_nanoduration.R
+++ b/inst/tinytest/test_nanoduration.R
@@ -30,7 +30,6 @@ expect_identical(as.nanoduration("0:00:01"), as.nanoduration(sec))
 expect_identical(as.nanoduration("0:00:00.001"), as.nanoduration(milli))
 expect_identical(c(as.nanoduration("1:00:00"), c(as.nanoduration("2:00:00"))),
                  c(as.nanoduration(hour), as.nanoduration(2*hour)))
-expect_identical(as.nanoduration(NA_integer64_), as.nanoduration(as.integer64("-9223372036854775808")))
 
 ## check name:
 n1 <- as.nanoduration(hour)
@@ -64,13 +63,13 @@ expect_identical(as.integer64(as.nanoduration(1:1000)), as.integer64(1:1000))
 d <- nanoduration(1,1,1,1)
 expect_identical(format(d), "01:01:01.000_000_001")
 expect_identical(format(-d), "-01:01:01.000_000_001")
-expect_true(is.na(format(as.nanoduration(as.integer64("-9223372036854775808")))))
+expect_true(is.na(format(as.nanoduration(NA_integer64_))))
 expect_identical(as.character(d), "01:01:01.000_000_001")
 expect_identical(as.character(-d), "-01:01:01.000_000_001")
-expect_true(is.na(as.character(as.nanoduration(as.integer64("-9223372036854775808")))))
+expect_true(is.na(as.character(as.nanoduration(NA_integer64_))))
 expect_stdout(show(d))
 expect_stdout(show(-d))
-expect_stdout(show(as.nanoduration(as.integer64("-9223372036854775808"))))
+expect_stdout(show(as.nanoduration(NA_integer64_)))
 
 ##test_print <- function() {
 d <- nanoduration(1,1,1,1)


### PR DESCRIPTION
```r
bit64::as.integer64("-9223372036854775808")
# integer64
# [1] <NA>
```

This has been and will continue to be the result, but in the next version of {bit64}, this will throw a warning, consistent with the 32-bit integer equivalent:

```r
as.integer('-2147483648')
# [1] NA
# Warning message:
# NAs introduced by coercion to integer range 
```

I don't _think_ this will require a new CRAN release _per se_ (I am not 100% sure how {tinytest} handles uncaught warnings), but I see this in the `R CMD check` log now:

```
  In addition: Warning messages:
  1: In as.integer64.character("-9223372036854775808") :
    NAs introduced by coercion to integer64 range
  2: In as.integer64.character("-9223372036854775808") :
    NAs introduced by coercion to integer64 range
  3: In as.integer64.character("-9223372036854775808") :
    NAs introduced by coercion to integer64 range
  4: In as.integer64.character("-9223372036854775808") :
    NAs introduced by coercion to integer64 range
```