### PR TITLE
Simplify seq.nanoduration for devel bit64

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2026-04-19  Michael Chirico  <michaelchirico4@gmail.com>
+
+ 	* R/nanoduration.R: Add a branch calling seq.integer64 more directly thanks to upstream fix
+
 2026-03-08  Dirk Eddelbuettel  <edd@debian.org>
 
  	* DESCRIPTION (Version, Date): Release 0.3.13

--- a/R/nanoduration.R
+++ b/R/nanoduration.R
@@ -674,6 +674,9 @@ as.data.frame.nanoduration <- function(x, ...) {
 ##' seq(from=as.nanoduration(0), by=as.nanoduration("01:00:00"), length.out=10)
 ##' @method seq nanoduration
 seq.nanoduration <- function(from, to=NULL, by=NULL, length.out=NULL, along.with=NULL, ...) {
+    if (packageVersion("bit64") >= "4.8.0") {
+      return(as.nanoduration(seq(as.integer64(from), to, by, length.out, along.with, ...)))
+    }
     ## workaroud 'bit64' bug:
     if (is.null(by)) {
         if (is.null(length.out)) {


### PR DESCRIPTION
Closes #151. This improves the test suite under the version of {bit64} on its way to CRAN (4.8.0).

Two PRs are needed to pass {bit64} 4.8.0:

 - #152 (this one)
 - #155

One PR reduces the noise of the suite on 4.8.0:

 - #149
