### PR TITLE
Attach nanotime after bit64

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2026-04-19  Michael Chirico  <michaelchirico4@gmail.com>
+
+ 	* R/nanoduration.R: Add a branch calling seq.integer64 more directly thanks to upstream fix
+
 2026-03-08  Dirk Eddelbuettel  <edd@debian.org>
 
  	* DESCRIPTION (Version, Date): Release 0.3.13

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,13 @@
 2026-04-19  Michael Chirico  <michaelchirico4@gmail.com>
 
+	* inst/tinytest/test_nanoduration.R: Attach nanotime after bit64 to ensure expected symbol resolution
+	* inst/tinytest/test_nanoival.R: Idem, and also resolve set operation functions correctly
+	* inst/tinytest/test_nanoperiod.R: Idem
+	* inst/tinytest/test_nanotime.R: Idem
+	* inst/tinytest/test_ops.R: Idem
+
+2026-04-19  Michael Chirico  <michaelchirico4@gmail.com>
+
  	* R/nanoduration.R: Add a branch calling seq.integer64 more directly thanks to upstream fix
 
 2026-03-08  Dirk Eddelbuettel  <edd@debian.org>

--- a/R/nanoduration.R
+++ b/R/nanoduration.R
@@ -674,6 +674,9 @@ as.data.frame.nanoduration <- function(x, ...) {
 ##' seq(from=as.nanoduration(0), by=as.nanoduration("01:00:00"), length.out=10)
 ##' @method seq nanoduration
 seq.nanoduration <- function(from, to=NULL, by=NULL, length.out=NULL, along.with=NULL, ...) {
+    if (packageVersion("bit64") >= "4.8.0") {
+      return(as.nanoduration(seq(as.integer64(from), to, by, length.out, along.with, ...)))
+    }
     ## workaroud 'bit64' bug:
     if (is.null(by)) {
         if (is.null(length.out)) {

--- a/inst/tinytest/test_nanoduration.R
+++ b/inst/tinytest/test_nanoduration.R
@@ -1,7 +1,7 @@
 
 suppressMessages({
-    library(nanotime)
     library(bit64)
+    library(nanotime)
 })
 options(digits=7)                       # needed for error message below
 

--- a/inst/tinytest/test_nanoival.R
+++ b/inst/tinytest/test_nanoival.R
@@ -1,5 +1,10 @@
-library(nanotime)
 suppressMessages(library(bit64))
+library(nanotime)
+
+# force nanotime S4 generics to resolve, not bit64 S3 generics
+intersect <- nanotime::intersect
+union <- nanotime::union
+setdiff <- nanotime::setdiff
 
 extended_tests <- Sys.getenv("CI", "") != ""
 

--- a/inst/tinytest/test_nanoperiod.R
+++ b/inst/tinytest/test_nanoperiod.R
@@ -1,7 +1,7 @@
 
 suppressMessages({
-    library(nanotime)
     library(bit64)
+    library(nanotime)
 })
 
 ## constructors

--- a/inst/tinytest/test_nanotime.R
+++ b/inst/tinytest/test_nanotime.R
@@ -1,7 +1,7 @@
 
 suppressMessages({
-    library(nanotime)
     library(bit64)
+    library(nanotime)
 })
 options(digits=7)                       # needed for error message of 0.3333333 below
 

--- a/inst/tinytest/test_ops.R
+++ b/inst/tinytest/test_ops.R
@@ -1,7 +1,7 @@
 
 suppressMessages({
-    library(nanotime)
     library(bit64)
+    library(nanotime)
 })
 
 ## ------------ `-`


### PR DESCRIPTION
Both {nanotime} and (newly!) {bit64} offer `intersect()` methods, but {bit64} does so _via_ S3.

That broke the test suite here because S4 dispatch would never happen since currently `bit64::intersect()` is found first. I tried a few ways to attempt S4 dispatch from within our S3 generic but it is proving elusive. I am open to ideas.

Meanwhile, #151 will require a new CRAN version, so a simple fix to the test suite here is to at least ensure `nanotime::intersect()` is found before `bit64::intersect()`. My sense is it's also a good choice in general to have the package you're testing higher in the `search()` path than its dependencies.

NB: the problem comes from the use of `intersect()` in `test_nanoival.R`, starting from:

https://github.com/eddelbuettel/nanotime/blob/e2486c401cc9ee2f75d36fdf7a36465e212b3998/inst/tinytest/test_nanoival.R#L603

Because of how {tinytest} works, running `library(bit64)` in tinytest.R is safest -- otherwise we get `library(nanotime)` in `test_data.frame.R` before `library(bit64)` in `test_nanoduration.R` and we're still in the original state of `intersect()` resolving incorrectly.

The change in `tinytest.R` alone would be sufficient; I've left the changes in `test_nano{duration,ival}.R` to allow `tinytest::run_test_file()` to keep working on those individual files too.